### PR TITLE
(SIMP-291) Modernize the Ciphers, MACs, and Kex

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -75,4 +75,22 @@ class ssh::server::params {
       $ciphers = $fallback_ciphers
     }
   }
+
+  # This should be removed once we move over to SSSD for everything.
+  if $::operatingsystem in ['RedHat','CentOS'] {
+    if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+      $_use_sssd = false
+    }
+    else {
+      $_use_sssd = true
+    }
+
+    $use_sssd = defined('$::use_sssd') ? {
+      true => $::use_sssd,
+      default => hiera('use_sssd',$_use_sssd)
+    }
+  }
+  else {
+    fail("${::operatingsystem} not yet supported by ${module_name}")
+  }
 }


### PR DESCRIPTION
Added explicit cases for FIPS and non-FIPS mode as well as reasonable
default cases for RHEL7 and below.

Also added support for the KexAlgorithms to get those reasonably in line
with the FIPS requirements out of the box.

SIMP-291 #close #comment Modern Updates