### PR TITLE
(SIMP-560) Changed default ssh server ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,17 @@ Please read our [Contribution Guide](https://simp-project.atlassian.net/wiki/dis
 
 Please excuse us as we transition this code into the public domain.
 
+## Ciphers
+At the time of this build, the strongest ciphers for use in ssh are
+aes128-gcm@openssh.com
+aes256-gcm@openssh.com
+Other allowable ciphers that can be included during install are:  
+aes128-cbc
+aes192-cbc
+aes256-cbc
+### Server
+The ciphers configured for use with the ssh server can be set to include all allowable ciphers or to include only the strongest ciphers, by default it is set to install all allowable ciphers.  Initially only the strongest ciphers were installed but in order to allow users to ssh into the server without updating the code a change was made.  (SIMP-560).  A setting was placed in the simp_def.yaml file  ssh::server::use_strong_ciphers_only.  this parameter is defaulted to false and it will install all the allowable ciphers during the initial simp config.  You can change this at any time after the install by simply editing the simp_def.yaml file.  
+###Client
+The ciphers configured for the ssh client are set to only the strongest ciphers.  In order to connect to a system that does not have these ciphers but uses the older ciphers you should use the command line option, 'ssh -c'.  See the man pages for further information.
+
 Downloads, discussion, and patches are still welcome!

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -8,8 +8,13 @@
 #
 class ssh::server::params {
   # These are all that are supported on RHEL6
+  $_use_strong_ciphers_only = hiera('ssh::server::params::use_strong_ciphers',false)
   $_fallback_kex_algorithms = [ 'diffie-hellman-group-exchange-sha256' ]
   $_fallback_macs = [ 'hmac-sha1' ]
+  $_strong_ciphers = [
+                'aes256-gcm@openssh.com',
+                'aes128-gcm@openssh.com' 
+  ]
   $_fallback_ciphers = [
     'aes256-cbc',
     'aes192-cbc',
@@ -27,10 +32,12 @@ class ssh::server::params {
         'hmac-sha2-256',
         'hmac-sha1'
       ]
-      $ciphers = [
-        'aes256-gcm@openssh.com',
-        'aes128-gcm@openssh.com'
-      ]
+      if $_use_strong_ciphers_only {
+	$ciphers = $_strong_ciphers
+      }
+      else {
+            $ciphers = split(inline_template("<%=(_strong_ciphers+_fallback_ciphers).join(',') %>"),',')
+      }
     }
     else {
       # Don't know what OS this is so fall back to whatever should work with
@@ -57,10 +64,12 @@ class ssh::server::params {
         'hmac-sha2-512',
         'hmac-sha2-256'
       ]
-      $ciphers = [
-        'aes256-gcm@openssh.com',
-        'aes128-gcm@openssh.com'
-      ]
+      if $_use_strong_ciphers_only {
+	$ciphers = $_strong_ciphers
+      }
+      else {
+            $ciphers = split(inline_template("<%=(_strong_ciphers+_fallback_ciphers).join(',') %>"),',')
+      }
     }
     else {
       # Don't know what OS this is so fall back to whatever should work with


### PR DESCRIPTION
A configuration parameter was added to simp_def.yaml to set what ciphers should
be configured for use by the ssh server. Only the strongest ciphers are configured
if ssh::server::config_strong_ciphers_only is set to true.
All available ciphers are configured if it is set to false.

simp-core was also updated (simp_def.yaml has the deault added.)

The default is false.