### PR TITLE
(SIMP-653) Updated to work around FIPS crash

### DIFF
--- a/build/pupmod-ssh.spec
+++ b/build/pupmod-ssh.spec
@@ -74,6 +74,10 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Fri Nov 20 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-11
+- Updated the code to work around a bug in the OpenSSH client where FIPS mode
+  fails if the 'Cipher' parameter is present in /etc/ssh/ssh_config
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-11
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -10,12 +10,19 @@
 #   Set this if you wish to automatically have the '*' Host entry set up with
 #   some sane defaults.
 #
+# [*use_fips*]
+# Type: Boolean
+# Default: false
+#   If set, adjust for FIPS mode. If FIPS is already enabled, this will be
+#   ignored.
+#
 # == Authors
 #
 # * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
 class ssh::client (
-  $add_default_entry = true
+  $add_default_entry = true,
+  $use_fips = defined('$::fips_enabled') ? { true => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 ){
 
   if $add_default_entry {

--- a/spec/defines/client/add_entry_spec.rb
+++ b/spec/defines/client/add_entry_spec.rb
@@ -8,12 +8,70 @@ describe 'ssh::client::add_entry' do
       end
 
       context "on #{os}" do
-
         let(:title) {'new_run'}
-
         context 'base' do
           it { should compile.with_all_deps }
-          it { should contain_concat_fragment('ssh_config+new_run.conf') }
+          it {
+            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              %r(Protocol 2$)
+            )
+            should contain_concat_fragment('ssh_config+new_run.conf').without_content(
+              %r(Cipher )
+            )
+          }
+        end
+
+        context 'with protocol == 1' do
+          let(:params){{ :protocol => '1' }}
+
+          it { should compile.with_all_deps }
+          it {
+            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              %r(Protocol 1$)
+            )
+            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              %r(Cipher )
+            )
+          }
+        end
+        context 'with protocol == 2,1' do
+          let(:params){{ :protocol => '2,1' }}
+
+          it { should compile.with_all_deps }
+          it {
+            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              %r(Protocol 2,1$)
+            )
+            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              %r(Cipher )
+            )
+          }
+        end
+
+        _protocol_sets = [
+          '1',
+          '2',
+          '1,2',
+          '2,1'
+        ]
+        _protocol_sets.each do |_protocol_set|
+          context "with protocol == #{_protocol_set} and use_fips" do
+            let(:params){{ :protocol => _protocol_set }}
+
+            _facts = facts.dup
+            _facts[:fips_enabled] = true
+            let(:facts){ _facts }
+
+            it { should compile.with_all_deps }
+            it {
+              should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+                %r(Protocol 2$)
+              )
+              should contain_concat_fragment('ssh_config+new_run.conf').without_content(
+                %r(Cipher )
+              )
+            }
+          end
         end
       end
     end

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -6,10 +6,13 @@
 -%>
 Host <%= @name %>
     AddressFamily <%= @address_family %>
+    Protocol <%= @_protocol %>
     BatchMode <%= bool_translate[@batchmode] %>
     ChallengeResponseAuthentication <%= bool_translate[@challengeresponseauthentication] %>
     CheckHostIP <%= bool_translate[@checkhostip] %>
-    Cipher <%= @cipher %>
+<% unless @_cipher.empty? -%>
+    Cipher <%= @_cipher %>
+<% end -%>
     Ciphers <%= @_ciphers.join(',') %>
     ClearAllForwardings <%= bool_translate[@clearallforwardings] %>
     Compression <%= bool_translate[@compression] %>
@@ -42,7 +45,6 @@ Host <%= @name %>
     PermitLocalCommand <%= bool_translate[@permitlocalcommand] %>
     Port <%= @port %>
     PreferredAuthentications <%= @preferredauthentications.join(',') %>
-    Protocol <%= @protocol %>
     PubkeyAuthentication <%= bool_translate[@pubkeyauthentication] %>
     RhostsRSAAuthentication <%= bool_translate[@rhostsrsaauthentication] %>
     RSAAuthentication <%= bool_translate[@rsaauthentication] %>
@@ -56,54 +58,54 @@ Host <%= @name %>
     VerifyHostKeyDNS <%= bool_translate[@verifyhostkeydns] %>
     VisualHostKey <%= bool_translate[@visualhostkey] %>
     XAuthLocation <%= @xauthlocation %>
-<% if !@bindaddress.eql?("nil") then -%>
+<% unless @bindaddress.empty? -%>
     BindAddress <%= @bindaddress %>
 <% end -%>
-<% if !@controlpath.eql?("nil") then -%>
+<% unless @controlpath.empty? -%>
     ControlPath <%= @controlpath %>
 <% end -%>
-<% if !@dynamicforward.eql?("nil") then -%>
+<% unless @dynamicforward.empty? -%>
     DynamicForward <%= @dynamicforward %>
 <% end -%>
-<% if !@globalknownhostsfile.eql?("nil") then -%>
+<% unless @globalknownhostsfile.empty? -%>
     GlobalKnownHostsFile <%= @globalknownhostsfile %>
 <% end -%>
-<% if !@hostkeyalias.eql?("nil") then -%>
+<% unless @hostkeyalias.empty? -%>
     HostKeyAlias <%= @hostkeyalias %>
 <% end -%>
-<% if !@hostname.eql?("nil") then -%>
+<% unless @hostname.empty? -%>
     HostName <%= @hostname %>
 <% end -%>
-<% if !@identityfile.eql?("nil") then -%>
+<% unless @identityfile.empty? -%>
     IdentityFile <%= @identityfile %>
 <% end -%>
-<% if !@kbdinteractivedevices.eql?("nil") then -%>
+<% unless @kbdinteractivedevices.empty? -%>
     KbdInteractiveDevices <%= @kbdinteractivedevices %>
 <% end -%>
-<% if !@localcommand.eql?("nil") then -%>
+<% unless @localcommand.empty? -%>
     LocalCommand <%= @localcommand %>
 <% end -%>
-<% if !@localforward.eql?("nil") then -%>
+<% unless @localforward.empty? -%>
     LocalForward <%= @localforward %>
 <% end -%>
-<% if !@proxycommand.eql?("nil") then -%>
+<% unless @proxycommand.empty? -%>
     ProxyCommand <%= @proxycommand %>
 <% end -%>
-<% if !@rekeylimit.eql?("nil") then -%>
+<% unless @rekeylimit.empty? -%>
     RekeyLimit <%= @rekeylimit %>
 <% end -%>
-<% if !@remoteforward.eql?("nil") then -%>
+<% unless @remoteforward.empty? -%>
     RemoteForward <%= @remoteforward %>
 <% end -%>
-<% if !@smartcarddevice.eql?("nil") then -%>
+<% unless @smartcarddevice.empty? -%>
     SmartcardDevice <%= @smartcarddevice %>
 <% end -%>
-<% if !@tunneldevice.eql?("nil") then -%>
+<% unless @tunneldevice.empty? -%>
     TunnelDevice <%= @tunneldevice %>
 <% end -%>
-<% if !@user.eql?("nil") then -%>
+<% unless @user.empty? -%>
     User <%= @user %>
 <% end -%>
-<% if !@userknownhostsfile.eql?("nil") then -%>
+<% unless @userknownhostsfile.empty? -%>
     UserKnownHostsFile <%= @userknownhostsfile %>
 <% end -%>


### PR DESCRIPTION
The SSH client crashes if you have the 'Cipher' variable *present* in
/etc/ssh/ssh_config and FIPS mode enable.

Also nailed the SSH Protocol to '2' if you're in FIPS mode because 1 is
not valid.

Ref: https://bugs.centos.org/view.php?id=9791

SIMP-653 #close