### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,16 +1,16 @@
 ---
 fixtures:
   repositories:
-    auditd: "git://github.com/simp/pupmod-simp-auditd"
-    augeasproviders_core: "git://github.com/simp/augeasproviders_core"
-    augeasproviders_grub: "git://github.com/simp/augeasproviders_grub"
-    augeasproviders_ssh: "git://github.com/simp/augeasproviders_ssh"
-    common: "git://github.com/simp/pupmod-simp-common"
-    simplib: "git://github.com/simp/pupmod-simp-simplib"
-    simpcat: "git://github.com/simp/pupmod-simp-concat"
-    iptables: "git://github.com/simp/pupmod-simp-iptables"
-    pki: "git://github.com/simp/pupmod-simp-pki"
-    stdlib: "git://github.com/simp/puppetlabs-stdlib"
-    tcpwrappers: "git://github.com/simp/pupmod-simp-tcpwrappers"
+    auditd:                "git://github.com/simp/pupmod-simp-auditd"
+    augeasproviders_core:  "git://github.com/simp/augeasproviders_core"
+    augeasproviders_grub:  "git://github.com/simp/augeasproviders_grub"
+    augeasproviders_ssh:   "git://github.com/simp/augeasproviders_ssh"
+    iptables:              "git://github.com/simp/pupmod-simp-iptables"
+    pki:                   "git://github.com/simp/pupmod-simp-pki"
+    simpcat:               "git://github.com/simp/pupmod-simp-concat"
+    simplib:               "git://github.com/simp/pupmod-simp-simplib"
+    sssd:                  "git://github.com/simp/pupmod-simp-sssd"
+    stdlib:                "git://github.com/simp/puppetlabs-stdlib"
+    tcpwrappers:           "git://github.com/simp/pupmod-simp-tcpwrappers"
   symlinks:
     ssh: "#{source_dir}"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-variables_not_enclosed-check
 --no-class_inherits_from_params_class-check
 --no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-    - 'bundle exec rake metadata'
-
 env:
   global:
     - STRICT_VARIABLES=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,38 +2,38 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'rake'
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'simp-rspec-puppet-facts'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
-  # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
-      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'vagrant-wrapper'
-  gem 'puppet-blacksmith'
-  gem 'guard'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
 end
@@ -41,4 +41,12 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -24,6 +24,7 @@ class ssh::client (
   $add_default_entry = true,
   $use_fips = defined('$::fips_enabled') ? { true => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 ){
+  validate_bool($add_default_entry)
 
   if $add_default_entry {
     ssh::client::add_entry { '*': }
@@ -51,6 +52,4 @@ class ssh::client (
   }
 
   package { 'openssh-clients': ensure => 'latest' }
-
-  validate_bool($add_default_entry)
 }

--- a/manifests/client/add_entry.pp
+++ b/manifests/client/add_entry.pp
@@ -277,7 +277,7 @@ define ssh::client::add_entry (
   if $::fips_enabled or $::enable_fips {
   }
 
-  concat_fragment { "ssh_config+$_name.conf":
+  concat_fragment { "ssh_config+${_name}.conf":
     content => template('ssh/ssh_config.erb')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@ class ssh (
   $enable_client = true,
   $enable_server = true
 ){
+  validate_bool($enable_client)
+  validate_bool($enable_server)
 
   if $enable_client { include 'ssh::client' }
   if $enable_server { include 'ssh::server' }
@@ -31,7 +33,4 @@ class ssh (
     group => 'root',
     mode  => '0755'
   }
-
-  validate_bool($enable_client)
-  validate_bool($enable_server)
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -17,6 +17,8 @@
 class ssh::server (
   $use_system_pki = true
 ){
+  validate_bool($use_system_pki)
+
   include 'ssh'
   include 'ssh::server::conf'
 
@@ -151,6 +153,4 @@ class ssh::server (
       mode  => '0644'
     }
   }
-
-  validate_bool($use_system_pki)
 }

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -127,7 +127,7 @@ class ssh::server::conf (
   }
 
   if !empty($authorizedkeyscommand) {
-    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::lsbmajdistrelease > '6' ) {
+    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
       if empty($authorizedkeyscommanduser) {
         fail('$authorizedkeyscommanduser must be set if $authorizedkeyscommand is set')
       }
@@ -197,7 +197,7 @@ class ssh::server::conf (
 
   if !empty($authorizedkeyscommand) {
     sshd_config { 'AuthorizedKeysCommand': value => $authorizedkeyscommand }
-    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::lsbmajdistrelease > '6' ) {
+    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
     }
   }
@@ -205,13 +205,13 @@ class ssh::server::conf (
     include '::sssd::install'
 
     sshd_config { 'AuthorizedKeysCommand': value => '/bin/sss_ssh_authorizedkeys' }
-    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::lsbmajdistrelease > '6' ) {
+    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
     }
   }
   elsif $_use_ldap {
     sshd_config { 'AuthorizedKeysCommand': value => '/usr/libexec/openssh/ssh-ldap-wrapper' }
-    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::lsbmajdistrelease > '6' ) {
+    if ( $::operatingsystem in ['RedHat','CentOS'] ) and ( $::operatingsystemmajrelease > '6' ) {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
     }
     file { '/etc/ssh/ldap.conf':

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -10,12 +10,12 @@ describe 'ssh::client' do
 
       context "on #{os}" do
 
-        it { should create_class('ssh::client') }
-        it { should compile.with_all_deps }
-        it { should create_ssh__client__add_entry('*') }
-        it { should create_concat_build('ssh_config').with_target('/etc/ssh/ssh_config') }
-        it { should create_file('/etc/ssh/ssh_config') }
-        it { should contain_package('openssh-clients').with_ensure('latest') }
+        it { is_expected.to create_class('ssh::client') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_ssh__client__add_entry('*') }
+        it { is_expected.to create_concat_build('ssh_config').with_target('/etc/ssh/ssh_config') }
+        it { is_expected.to create_file('/etc/ssh/ssh_config') }
+        it { is_expected.to contain_package('openssh-clients').with_ensure('latest') }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,11 +10,11 @@ describe 'ssh' do
       context "on #{os}" do
 
         describe "a fact set init" do
-          it { should create_class('ssh') }
-          it { should compile.with_all_deps }
-          it { should create_file('/etc/ssh') }
-          it { should create_file('/etc/ssh/ssh_host_key') }
-          it { should create_file('/etc/ssh/ssh_known_hosts') }
+          it { is_expected.to create_class('ssh') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/ssh') }
+          it { is_expected.to create_file('/etc/ssh/ssh_host_key') }
+          it { is_expected.to create_file('/etc/ssh/ssh_known_hosts') }
         end
 
       end

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -10,10 +10,10 @@ describe 'ssh::server::conf' do
 
       context "on #{os}" do
         shared_examples_for "a fact set conf" do
-          it { should create_class('ssh::server::conf') }
-          it { should compile.with_all_deps }
-          it { should create_file('/etc/ssh/sshd_config') }
-          it { should create_file('/etc/ssh/local_keys') }
+          it { is_expected.to create_class('ssh::server::conf') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_file('/etc/ssh/sshd_config') }
+          it { is_expected.to create_file('/etc/ssh/local_keys') }
         end
 
         describe "RHEL 6" do
@@ -25,7 +25,7 @@ describe 'ssh::server::conf' do
             :grub_version => '0.97',
             :hardwaremodel => 'x86_64',
             :operatingsystem => 'RedHat',
-            :lsbmajdistrelease => '6',
+            :operatingsystemmajrelease => '6',
             :operatingsystemmajrelease => '6',
             :interfaces => 'eth0,lo'
           }}
@@ -40,7 +40,7 @@ describe 'ssh::server::conf' do
             :grub_version => '2.0.2~beta2',
             :hardwaremodel => 'x86_64',
             :operatingsystem => 'RedHat',
-            :lsbmajdistrelease => '7',
+            :operatingsystemmajrelease => '7',
             :operatingsystemmajrelease => '7',
             :interfaces => 'eth0,lo'
           }}

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,34 +1,34 @@
 require 'spec_helper'
 
 shared_examples_for "an ssh server" do
-  it { should create_class('ssh::server') }
-  it { should compile.with_all_deps }
-  it { should contain_class('ssh') }
+  it { is_expected.to create_class('ssh::server') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to contain_class('ssh') }
 
-  it { should create_file('/var/empty/sshd').with({
+  it { is_expected.to create_file('/var/empty/sshd').with({
       :ensure  => 'directory',
       :require => 'Package[openssh-server]'
     })
   }
 
-  it { should create_file('/var/empty/sshd/etc').with({
+  it { is_expected.to create_file('/var/empty/sshd/etc').with({
       :ensure  => 'directory',
       :require => 'Package[openssh-server]'
     })
   }
 
-  it { should create_file('/var/empty/sshd/etc/localtime').with({
+  it { is_expected.to create_file('/var/empty/sshd/etc/localtime').with({
       :source  => '/etc/localtime',
       :require => 'Package[openssh-server]'
     })
   }
 
-  it { should contain_group('sshd') }
+  it { is_expected.to contain_group('sshd') }
 
-  it { should contain_package('openssh-server').with_ensure('latest') }
-  it { should contain_package('openssh-ldap').with_ensure('latest') }
+  it { is_expected.to contain_package('openssh-server').with_ensure('latest') }
+  it { is_expected.to contain_package('openssh-ldap').with_ensure('latest') }
 
-  it { should contain_user('sshd').with({
+  it { is_expected.to contain_user('sshd').with({
       :ensure    => 'present',
       :allowdupe => false,
       :gid       => '74',
@@ -36,7 +36,7 @@ shared_examples_for "an ssh server" do
     })
   }
 
-  it { should contain_service('sshd').with({
+  it { is_expected.to contain_service('sshd').with({
       :ensure  => 'running',
       :require => 'Package[openssh-server]'
     })

--- a/spec/defines/client/add_entry_spec.rb
+++ b/spec/defines/client/add_entry_spec.rb
@@ -10,12 +10,12 @@ describe 'ssh::client::add_entry' do
       context "on #{os}" do
         let(:title) {'new_run'}
         context 'base' do
-          it { should compile.with_all_deps }
+          it { is_expected.to compile.with_all_deps }
           it {
-            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 2$)
             )
-            should contain_concat_fragment('ssh_config+new_run.conf').without_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').without_content(
               %r(Cipher )
             )
           }
@@ -24,12 +24,12 @@ describe 'ssh::client::add_entry' do
         context 'with protocol == 1' do
           let(:params){{ :protocol => '1' }}
 
-          it { should compile.with_all_deps }
+          it { is_expected.to compile.with_all_deps }
           it {
-            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 1$)
             )
-            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
               %r(Cipher )
             )
           }
@@ -37,12 +37,12 @@ describe 'ssh::client::add_entry' do
         context 'with protocol == 2,1' do
           let(:params){{ :protocol => '2,1' }}
 
-          it { should compile.with_all_deps }
+          it { is_expected.to compile.with_all_deps }
           it {
-            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 2,1$)
             )
-            should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
               %r(Cipher )
             )
           }
@@ -62,12 +62,12 @@ describe 'ssh::client::add_entry' do
             _facts[:fips_enabled] = true
             let(:facts){ _facts }
 
-            it { should compile.with_all_deps }
+            it { is_expected.to compile.with_all_deps }
             it {
-              should contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
                 %r(Protocol 2$)
               )
-              should contain_concat_fragment('ssh_config+new_run.conf').without_content(
+              is_expected.to contain_concat_fragment('ssh_config+new_run.conf').without_content(
                 %r(Cipher )
               )
             }


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independent)
`operatingsystem*` counterparts.

Also:
- normalized common static module assets
- corrected a lint error
- moved parameter validations to the top of each class
- updated rspec tests to the new `expect` syntax

SIMP-674 #close
SIMP-398 #comment updated `pupmod-simp-ssh`
SIMP-667 #comment updated `pupmod-simp-ssh`