### PR TITLE
Fix error in Puppet 4 compilation

### DIFF
--- a/manifests/client/add_entry.pp
+++ b/manifests/client/add_entry.pp
@@ -274,9 +274,6 @@ define ssh::client::add_entry (
 
   $_use_fips = defined('$::fips_enabled') ? { true => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 
-  if $::fips_enabled or $::enable_fips {
-  }
-
   concat_fragment { "ssh_config+${_name}.conf":
     content => template('ssh/ssh_config.erb')
   }


### PR DESCRIPTION
Previous to this commit, the module would not compile in Puppet 4 due to
an used conditional in the ssh::client::add_entry defined type.  The
Puppet 4 compiler disallows code that can never be executed, failing
with the following error: "Evaluation Error: Error while evaluating a
Resource Statement, This 'if' statement has no effect. A value was
produced and then forgotten (one or more preceding expressions may have
the wrong form)"

This commit removes the unused conditional.