### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,7 @@ fixtures:
     augeasproviders_core:  "git://github.com/simp/augeasproviders_core"
     augeasproviders_grub:  "git://github.com/simp/augeasproviders_grub"
     augeasproviders_ssh:   "git://github.com/simp/augeasproviders_ssh"
+    compliance: "https://github.com/trevor-vaughan/pupmod-compliance"
     iptables:              "git://github.com/simp/pupmod-simp-iptables"
     pki:                   "git://github.com/simp/pupmod-simp-pki"
     simpcat:               "git://github.com/simp/pupmod-simp-concat"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log


### PR DESCRIPTION
This commit synchronizes all common static module assets with current
SIMP module standards.

Also:
- added `compliance` module to `.fixtures.yml` to keep spec tests passing

SIMP-667 #comment updated `pupmod-simp-ssh`
