### PR TITLE
(SIMP-918) Ensure that EL6.7+ uses SSSD over NSCD

### DIFF
--- a/build/pupmod-ssh.spec
+++ b/build/pupmod-ssh.spec
@@ -1,7 +1,7 @@
 Summary: SSH Puppet Module
 Name: pupmod-ssh
 Version: 4.1.0
-Release: 14
+Release: 15
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -76,6 +76,9 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Mon Mar 14 2016 Nick Markowski <nmarkowski@keywcorp.com. - 4.1.0-15
+- Ensure that EL6.7+ uses SSSD over NSCD
+
 * Thu Feb 25 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-14
 - Added compliance function support
 

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -78,7 +78,7 @@ class ssh::server::params {
 
   # This should be removed once we move over to SSSD for everything.
   if $::operatingsystem in ['RedHat','CentOS'] {
-    if versioncmp($::operatingsystemmajrelease,'7') < 0 {
+    if (versioncmp($::operatingsystemmajrelease,'6.7') < 0) {
       $_use_sssd = false
     }
     else {


### PR DESCRIPTION
- Modified params to ensure proper sssd use.
- Set challengeauthresponse to true despite compliance mapping.
  We use PAM by default, which requires challengeauthresponse=true
  to interract with sshd.

SIMP-918 #comment nscd < EL6.7
SIMP-919 #close challengeauthresponse=true