### PR TITLE
(SIMP-826) Update kex algorithms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
+  gem "hiera-puppet-helper"
 
   # dependency hacks:
   gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
@@ -36,6 +37,8 @@ group :development do
   gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
+  # Listen >= 3.1.X requires ruby 2.2, freeze at 3.0.6
+  gem 'listen', '3.0.6'
 end
 
 group :system_tests do

--- a/build/pupmod-ssh.spec
+++ b/build/pupmod-ssh.spec
@@ -1,6 +1,6 @@
 Summary: SSH Puppet Module
 Name: pupmod-ssh
-Version: 4.1.2
+Version: 4.2.0
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -76,6 +76,12 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Wed Apr 20 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-0
+- Created an openssh_version fact.
+- Modified kex algorithm set:
+  - No longer set kex prior to openssh v 5.7
+  - Curve25519 kex only set in openssh v 6.5+
+
 * Tue Mar 23 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.2-0
 - Openssh-ldap is no longer installed when use_sssd is true.
 

--- a/lib/facter/openssh_version.rb
+++ b/lib/facter/openssh_version.rb
@@ -1,0 +1,15 @@
+# _Description_
+#
+# Return the version of sshd
+#
+if Facter.value(:kernel).downcase == "linux" then
+  Facter.add("openssh_version") do
+    setcode do
+     # There is no explicit version or help flag for sshd.  Pass
+     # a garbage '--version' flag, and grab the output.
+     sshd_out = %x[/sbin/sshd --version 2>&1]
+     version = sshd_out[/(?<=OpenSSH.)(\d|\.)+/]
+     version
+    end
+  end
+end

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -190,7 +190,8 @@ class ssh::server::conf (
   sshd_config{ 'Compression': value => ssh_config_bool_translate($compression) }
   sshd_config{ 'SyslogFacility': value => $syslogfacility}
   sshd_config{ 'GSSAPIAuthentication': value => ssh_config_bool_translate($gssapiauthentication) }
-  sshd_config{ 'KexAlgorithms': value => $kex_algorithms }
+  # Kex should be empty openssl < 5.7, they are not supported.
+  if !empty($kex_algorithms) { sshd_config{ 'KexAlgorithms': value => $kex_algorithms } }
   sshd_config{ 'ListenAddress': value => $listenaddress }
   sshd_config{ 'Port': value => $port }
   sshd_config{ 'MACs': value => $macs }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "pupmod-simp-ssh",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "author":  "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,6 +10,7 @@ describe 'ssh' do
       context "on #{os}" do
 
         describe "a fact set init" do
+          let(:facts) { facts.merge( { :openssh_version => '6.6' } ) }
           it { is_expected.to create_class('ssh') }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/ssh') }

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -10,6 +10,7 @@ describe 'ssh::server::conf' do
 
       context "on #{os}" do
         shared_examples_for "a fact set conf" do
+          let(:facts) { facts.merge( { :openssh_version => '6.6' } ) }
           it { is_expected.to create_class('ssh::server::conf') }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/ssh/sshd_config') }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -49,25 +49,98 @@ describe 'ssh::server' do
         let(:facts) do
           facts
         end
+        let(:facts) { facts.merge( { :openssh_version => '6.6' } ) }
         context "with default parameters" do
           it_behaves_like "an ssh server"
 
           if (['RedHat', 'CentOS'].include?(facts[:operatingsystem]))
             if (facts[:operatingsystemmajrelease].to_s >= '7')
-              it { is_expected.to contain_sshd_config('Ciphers').with_value(
-                   ['aes256-gcm@openssh.com',
-                   'aes128-gcm@openssh.com',
-                   'aes256-cbc',
-                   'aes192-cbc',
-                   'aes128-cbc'])
-              }
+              context "with fips enabled" do
+                let(:facts) { facts.merge( { :fips_enabled => true, :openssh_version => '6.6' } ) }
+                it { is_expected.to contain_sshd_config('Ciphers').with_value(
+                     ['aes256-gcm@openssh.com',
+                     'aes128-gcm@openssh.com',
+                     'aes256-cbc',
+                     'aes192-cbc',
+                     'aes128-cbc'])
+                }
+                it { is_expected.to contain_sshd_config('MACs').with_value(
+                     ['hmac-sha2-256',
+                     'hmac-sha1'])
+                }
+                context "with openssh_version 6.6" do
+                  it { is_expected.to contain_sshd_config('KexAlgorithms').with_value(
+                       ['ecdh-sha2-nistp521',
+                       'ecdh-sha2-nistp384',
+                       'ecdh-sha2-nistp256',
+                       'diffie-hellman-group-exchange-sha256'])
+                  }
+                end
+                context "with openssh_version 5.6" do
+                  let(:facts) { facts.merge( { :openssh_version => '5.6' } ) }
+                  it { is_expected.to_not contain_sshd_config('KexAlgorithms') }
+                end
+              end
+              context "with fips disabled" do
+                let(:facts) { facts.merge( { :fips_enabled => false, :openssh_version => '6.6' } ) }
+                it { is_expected.to contain_sshd_config('Ciphers').with_value(
+                     ['aes256-gcm@openssh.com',
+                     'aes128-gcm@openssh.com',
+                     'aes256-cbc',
+                     'aes192-cbc',
+                     'aes128-cbc'])
+                }
+                it { is_expected.to contain_sshd_config('MACs').with_value(
+                     ['hmac-sha2-512-etm@openssh.com',
+                     'hmac-sha2-256-etm@openssh.com',
+                     'hmac-sha2-512',
+                     'hmac-sha2-256'])
+                }
+                context "with openssh_version 6.6" do
+                  it { is_expected.to contain_sshd_config('KexAlgorithms').with_value(
+                       ['curve25519-sha256@libssh.org',
+                       'ecdh-sha2-nistp521',
+                       'ecdh-sha2-nistp384',
+                       'ecdh-sha2-nistp256',
+                       'diffie-hellman-group-exchange-sha256'])
+                  }
+                end
+                context "with openssh_version 6.4" do
+                  let(:facts) { facts.merge( { :openssh_version => '6.4' } ) }
+                  it { is_expected.to contain_sshd_config('KexAlgorithms').with_value(
+                       ['ecdh-sha2-nistp521',
+                       'ecdh-sha2-nistp384',
+                       'ecdh-sha2-nistp256',
+                       'diffie-hellman-group-exchange-sha256'])
+                  }
+                end
+                context "with openssh_version 5.6" do
+                  let(:facts) { facts.merge( { :openssh_version => '5.6' } ) }
+                  it { is_expected.to_not contain_sshd_config('KexAlgorithms') }
+                end
+              end
+            # Not EL 7+ OS
             else
               it { is_expected.to contain_sshd_config('Ciphers').with_value(
                    ['aes256-cbc',
                    'aes192-cbc',
                    'aes128-cbc'])
               }
+              it { is_expected.to contain_sshd_config('MACs').with_value(
+                   ['hmac-sha1'])
+              }
+              context "with openssh_version 6.6" do
+                let(:facts) { facts.merge( { :openssh_version => '6.6' } ) }
+                it { is_expected.to contain_sshd_config('KexAlgorithms').with_value(
+                     ['diffie-hellman-group-exchange-sha256'])
+                }
+              end
+              context "with openssh_version 5.6" do
+                let(:facts) { facts.merge( { :openssh_version => '5.6' } ) }
+                it { is_expected.to_not contain_sshd_config('KexAlgorithms') }
+              end
             end
+
             if (facts[:operatingsystemrelease].to_s < '6.7')
               it { is_expected.to contain_package('openssh-ldap').with_ensure('latest') }
             else


### PR DESCRIPTION
- Created an openssh_version fact.
- Modified kex algorithm set:
  - No longer set kex prior to openssh v 5.7.
  - Curve25519 kex only set in openssh v 6.5+.

SIMP-826 #close
