### PR TITLE
(SIMP-1211) Ensure that semanage handles ports

### DIFF
--- a/build/pupmod-ssh.spec
+++ b/build/pupmod-ssh.spec
@@ -1,6 +1,6 @@
 Summary: SSH Puppet Module
 Name: pupmod-ssh
-Version: 4.1.3
+Version: 4.1.4
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -76,6 +76,10 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Sat May 21 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.4-0
+- Ensure that we set the proper SELinux port connection options for sshd if
+  using a non-standard port.
+
 * Wed Apr 20 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.3-0
 - Created an openssh_version fact.
 - Modified kex algorithm set:

--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -15,7 +15,10 @@ class ssh::client::params {
     'aes128-cbc'
   ]
   if $::fips_enabled {
-    if $::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0 {
+    if (
+      ($::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0) or
+      ($::operatingsystem in ['Fedora'] and versioncmp($::operatingsystemmajrelease,'22') >= 0)
+    ) {
       $macs = [
         'hmac-sha2-256',
         'hmac-sha1'
@@ -34,7 +37,10 @@ class ssh::client::params {
     }
   }
   else {
-    if $::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0 {
+    if (
+      ($::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0) or
+      ($::operatingsystem in ['Fedora'] and versioncmp($::operatingsystemmajrelease,'22') >= 0)
+    ) {
       # FIPS mode not enabled, stay within the bounds but expand the options
       $macs = [
         'hmac-sha2-512-etm@openssh.com',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -117,6 +117,21 @@ class ssh::server (
     subscribe  => Class['::ssh::server::conf']
   }
 
+  if to_string($::ssh::server::conf::port) != '22' and defined('$::selinux_enforced') and str2bool(getvar('::selinux_enforced')) {
+    # This should really be a custom type...
+    exec { "SELinux Allow SSH Port ${::ssh::server::conf::port}":
+      command => "semanage port -a -t ssh_port_t -p tcp ${::ssh::server::conf::port}",
+      unless  => "semanage port -C -l | grep -qe 'ssh_port_t[[:space:]]*tcp[[:space:]]*${::ssh::server::conf::port}'",
+      path    => [
+        '/usr/local/sbin',
+        '/usr/local/bin',
+        '/usr/sbin',
+        '/usr/bin'
+      ],
+      notify  => Service['sshd']
+    }
+  }
+
   if $use_simp_pki {
     include '::pki'
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -129,7 +129,7 @@ class ssh::server::conf (
   }
 
   if !empty($authorizedkeyscommand) {
-    if ( $::operatingsystem in ['RedHat','CentOS'] )
+    if ( $::operatingsystem in ['RedHat','CentOS','Fedora'] )
       and ( versioncmp($::operatingsystemmajrelease,'6') > 0 )
     {
       if empty($authorizedkeyscommanduser) {
@@ -206,7 +206,7 @@ class ssh::server::conf (
 
   if !empty($authorizedkeyscommand) {
     sshd_config { 'AuthorizedKeysCommand': value => $authorizedkeyscommand }
-    if ( $::operatingsystem in ['RedHat','CentOS'] )
+    if ( $::operatingsystem in ['RedHat','CentOS','Fedora'] )
       and ( versioncmp($::operatingsystemmajrelease,'6') > 0 )
     {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
@@ -216,7 +216,7 @@ class ssh::server::conf (
     include '::sssd::install'
 
     sshd_config { 'AuthorizedKeysCommand': value => '/bin/sss_ssh_authorizedkeys' }
-    if ( $::operatingsystem in ['RedHat','CentOS'] )
+    if ( $::operatingsystem in ['RedHat','CentOS','Fedora'] )
       and ( versioncmp($::operatingsystemmajrelease,'6') > 0 )
     {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
@@ -224,7 +224,7 @@ class ssh::server::conf (
   }
   elsif $_use_ldap {
     sshd_config { 'AuthorizedKeysCommand': value => '/usr/libexec/openssh/ssh-ldap-wrapper' }
-    if ( $::operatingsystem in ['RedHat','CentOS'] )
+    if ( $::operatingsystem in ['RedHat','CentOS','Fedora'] )
       and ( versioncmp($::operatingsystemmajrelease,'6') > 0 )
     {
       sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -31,7 +31,10 @@ class ssh::server::params {
   ]
 
   if $::fips_enabled {
-    if $::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0 {
+    if (
+      ($::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0) or
+      ($::operatingsystem in ['Fedora'] and versioncmp($::operatingsystemmajrelease,'22') >= 0)
+    ) {
 
       if versioncmp($::openssh_version, '5.7') >= 0 {
         $kex_algorithms = [
@@ -64,7 +67,10 @@ class ssh::server::params {
     }
   }
   else {
-    if $::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0 {
+    if (
+      ($::operatingsystem in ['RedHat','CentOS'] and versioncmp($::operatingsystemmajrelease,'7') >= 0) or
+      ($::operatingsystem in ['Fedora'] and versioncmp($::operatingsystemmajrelease,'22') >= 0)
+    ) {
       # FIPS mode not enabled, stay within the bounds but expand the options
 
       if versioncmp($::openssh_version, '5.7') >= 0 {
@@ -108,7 +114,7 @@ class ssh::server::params {
   }
 
   # This should be removed once we move over to SSSD for everything.
-  if $::operatingsystem in ['RedHat','CentOS'] {
+  if $::operatingsystem in ['RedHat','CentOS','Fedora'] {
     if (versioncmp($::operatingsystemrelease,'6.7') < 0) {
       $_use_sssd = false
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "pupmod-simp-ssh",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author":  "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -75,6 +75,12 @@
       "operatingsystemrelease": [
         "6",
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "23"
       ]
     }
   ]


### PR DESCRIPTION
Cutom ports would not work if SELinux was enforcing due to the absence
of a semanage call to set the port properly.

Also updated for testing against fedora 23

SIMP-1211 #close