### PR TITLE
(SIMP-1144) The openssh_version fact is now compatible with ruby 1.8.7.

### DIFF
--- a/build/pupmod-ssh.spec
+++ b/build/pupmod-ssh.spec
@@ -1,6 +1,6 @@
 Summary: SSH Puppet Module
 Name: pupmod-ssh
-Version: 4.1.3
+Version: 4.1.4
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -76,6 +76,9 @@ fi
 # Post uninitall stuff
 
 %changelog
+* Tue Jun 07 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.4-0
+- The openssh_version fact is now compatible with ruby 1.8.7.
+
 * Wed Apr 20 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.3-0
 - Created an openssh_version fact.
 - Modified kex algorithm set:

--- a/lib/facter/openssh_version.rb
+++ b/lib/facter/openssh_version.rb
@@ -13,9 +13,12 @@ Facter.add("openssh_version") do
     version = 'UNKNOWN'
 
     # There is no explicit version or help flag for sshd.  Pass
-    # a garbage '--version' flag, and grab the output.
-    sshd_out = Facter::Core::Execution.exec(%(#{sshd_command} --version 2>&1))
-    version = sshd_out[/(?<=OpenSSH.)(\d|\.)+/] unless sshd_out.nil?
+    # a garbage '-v' flag, and grab the output.
+    sshd_out = Facter::Core::Execution.execute(%(#{sshd_command} -v 2>&1))
+
+    # Case insensitive match to openssh followed by any characters (or no characters),
+    # proceeded by digits(any number) and decimals.  Return the digits and decimals.
+    version = sshd_out.match(/OpenSSH\D*((\d+|\.)+)/i)[1].strip
 
     version
   end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "pupmod-simp-ssh",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author":  "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
The new regex is less strict which should make it more robust.

SIMP-1144 #close