### PR TITLE
(SIMP-1142) Change SSH defaults to assume non-SIMP

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -6,7 +6,7 @@
 #
 # [*use_simp_pki*]
 # Type: Boolean
-# Default: true
+# Default: false
 #   If true, will include 'pki' and then use the certificates that are
 #   transferred to generate the system SSH certificates for consistency.
 #
@@ -15,7 +15,7 @@
 # * Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
 class ssh::server (
-  $use_simp_pki = defined('$::use_simp_pki') ? { true => $::use_simp_pki, default => hiera('use_simp_pki', true) }
+  $use_simp_pki = defined('$::use_simp_pki') ? { true => $::use_simp_pki, default => hiera('use_simp_pki', false) }
 ){
   validate_bool($use_simp_pki)
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -27,7 +27,7 @@
 #
 # [*enable_fallback_ciphers*]
 # Type: Boolean
-# Default: true
+# Default: false
 #   If true, add the fallback ciphers from ssh::server::params to the cipher
 #   list. This is intended to provide compatibility with non-SIMP systems in a
 #   way that properly supports FIPS 140-2.
@@ -50,19 +50,19 @@
 #
 # [*use_iptables*]
 # Type: Boolean
-# Default: hiera('use_iptables',true)
+# Default: hiera('use_iptables',false)
 #   If true, use the SIMP iptables class.
 #
 # [*use_ldap*]
 # Type: Boolean
-# Default: hiera('use_ldap',true)
+# Default: hiera('use_ldap',false)
 #   If true, enable LDAP support on the system.
 #   If authorizedkeyscommand is empty, this will set the authorizedkeyscommand
 #   to ssh-ldap-wrapper so that SSH public keys can be stored directly in LDAP.
 #
 # [*use_tcpwrappers]
 # Type: Boolean
-# Default: true
+# Default: false
 #   If true, allow sshd tcpwrapper.
 #
 # == Authors
@@ -93,7 +93,7 @@ class ssh::server::conf (
   $challengeresponseauthentication = false,
   $ciphers = $::ssh::server::params::ciphers,
   $fallback_ciphers = $::ssh::server::params::fallback_ciphers,
-  $enable_fallback_ciphers = true,
+  $enable_fallback_ciphers = false,
   $compression = false,
   $syslogfacility = 'AUTHPRIV',
   $gssapiauthentication = false,
@@ -109,10 +109,10 @@ class ssh::server::conf (
   $useprivilegeseparation = true,
   $x11forwarding = false,
   $client_nets = 'any',
-  $use_iptables = hiera('use_iptables',true),
-  $use_ldap = hiera('use_ldap',true),
+  $use_iptables = hiera('use_iptables',false),
+  $use_ldap = hiera('use_ldap',false),
   $use_sssd = $::ssh::server::params::use_sssd,
-  $use_tcpwrappers = true
+  $use_tcpwrappers = false
 ) inherits ::ssh::server::params {
   assert_private()
 


### PR DESCRIPTION
The SSH module will now assume that you are using it in a non-SIMP
environment. All features are still available and can be set with global
Hiera variables.

SIMP-1142 #close
