### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.11-0
+- Fix Forge `haveged` dependency name
+
 * Tue Sep 06 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.10-0
 - Modified AuthorizedKeysCommand to be /usr/bin/sss_ssh_authorizedkeys
   if sssd is enabled.

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,16 @@
 {
-  "name":    "simp-ssh",
-  "version": "4.1.10",
-  "author":  "simp",
+  "name": "simp-ssh",
+  "version": "4.1.11",
+  "author": "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-ssh",
+  "source": "https://github.com/simp/pupmod-simp-ssh",
   "project_page": "https://github.com/simp/pupmod-simp-ssh",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "ssh" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "ssh"
+  ],
   "dependencies": [
     {
       "name": "simp/common",
@@ -34,7 +37,7 @@
       "version_requirement": ">= 2.5.0"
     },
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-ssh