### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.11-0
 - Fix Forge `haveged` dependency name
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -2,7 +2,7 @@ Requires: pupmod-herculesteam-augeasproviders_ssh
 Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-iptables >= 4.1.0-3
 Requires: pupmod-simp-haveged >= 0.3.0-0
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Provides: pupmod-ssh-augeas-lenses >= 4.1.2-0
 Obsoletes: pupmod-ssh-augeas-lenses <= 4.1.2-0
 Obsoletes: pupmod-ssh-test >= 0.0.1

--- a/lib/puppet/parser/functions/ssh_format_host_entry_for_sorting.rb
+++ b/lib/puppet/parser/functions/ssh_format_host_entry_for_sorting.rb
@@ -3,7 +3,7 @@ module Puppet::Parser::Functions
     A method to sensibly format sort SSH 'host' entries which contain wildcards
     and question marks.
 
-    The output is intended for use with the concat_fragment type and is *not*
+    The output is intended for use with the simpcat_fragment type and is *not*
     meant for use as a host entry itself.
 
     The general idea is that it places all items at the bottom of the list

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -40,7 +40,7 @@ class ssh::client (
     ssh::client::add_entry { '*': }
   }
 
-  concat_build { 'ssh_config':
+  simpcat_build { 'ssh_config':
     order   => ['*.conf'],
     target  => '/etc/ssh/ssh_config',
     require => Package['openssh-clients']
@@ -56,7 +56,7 @@ class ssh::client (
     owner     => 'root',
     group     => 'root',
     mode      => '0644',
-    subscribe => Concat_build['ssh_config'],
+    subscribe => Simpcat_build['ssh_config'],
     require   => Package['openssh-clients'],
     audit     => content
   }

--- a/manifests/client/add_entry.pp
+++ b/manifests/client/add_entry.pp
@@ -274,7 +274,7 @@ define ssh::client::add_entry (
 
   $_use_fips = defined('$::fips_enabled') ? { true => str2bool($::fips_enabled), default => hiera('use_fips', false) }
 
-  concat_fragment { "ssh_config+${_name}.conf":
+  simpcat_fragment { "ssh_config+${_name}.conf":
     content => template('ssh/ssh_config.erb')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "4.1.11",
+  "version": "5.0.0",
   "author": "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -17,8 +17,8 @@
       "version_requirement": ">= 4.2.0"
     },
     {
-      "name": "simp/concat",
-      "version_requirement": ">= 4.0.0"
+      "name": "simp/simpcat",
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/auditd",

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -13,7 +13,7 @@ describe 'ssh::client' do
           it { is_expected.to create_class('ssh::client') }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_ssh__client__add_entry('*') }
-          it { is_expected.to create_concat_build('ssh_config').with_target('/etc/ssh/ssh_config') }
+          it { is_expected.to create_simpcat_build('ssh_config').with_target('/etc/ssh/ssh_config') }
           it { is_expected.to create_file('/etc/ssh/ssh_config') }
           it { is_expected.to contain_package('openssh-clients').with_ensure('latest') }
           it { is_expected.to contain_class('haveged') }

--- a/spec/defines/client/add_entry_spec.rb
+++ b/spec/defines/client/add_entry_spec.rb
@@ -12,10 +12,10 @@ describe 'ssh::client::add_entry' do
         context 'base' do
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 2$)
             )
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').without_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').without_content(
               %r(Cipher )
             )
           }
@@ -26,10 +26,10 @@ describe 'ssh::client::add_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 1$)
             )
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
               %r(Cipher )
             )
           }
@@ -39,10 +39,10 @@ describe 'ssh::client::add_entry' do
 
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
               %r(Protocol 2,1$)
             )
-            is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+            is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
               %r(Cipher )
             )
           }
@@ -64,10 +64,10 @@ describe 'ssh::client::add_entry' do
 
             it { is_expected.to compile.with_all_deps }
             it {
-              is_expected.to contain_concat_fragment('ssh_config+new_run.conf').with_content(
+              is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').with_content(
                 %r(Protocol 2$)
               )
-              is_expected.to contain_concat_fragment('ssh_config+new_run.conf').without_content(
+              is_expected.to contain_simpcat_fragment('ssh_config+new_run.conf').without_content(
                 %r(Cipher )
               )
             }


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'ssh'
