### PR TITLE
(SIMP-1591) Fix old dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 30 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.12-0
+- Fixed dependencies in `metadata.json` prior to a Forge push.
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.11-0
 - Fix Forge `haveged` dependency name
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "4.1.11",
+  "version": "4.1.12",
   "author": "simp",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -13,11 +13,11 @@
   ],
   "dependencies": [
     {
-      "name": "simp/common",
+      "name": "simp/simplib",
       "version_requirement": ">= 4.2.0"
     },
     {
-      "name": "simp/concat",
+      "name": "simp/simpcat",
       "version_requirement": ">= 4.0.0"
     },
     {


### PR DESCRIPTION
`simp/common` and `simp/concat` are listed as dependencies in
`metadata.json`, which breaks resolution when installing from the Forge.

This patch fixes the issue by keeping references to `simp/simplib` and
`simp/simpcat`.

SIMP-1591 #close