### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,28 +1,44 @@
 ---
 fixtures:
   repositories:
-    auditd:                "https://github.com/simp/pupmod-simp-auditd"
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      branch: 5.X
     augeasproviders_core:
-      repo:   "https://github.com/simp/augeasproviders_core"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_core
     augeasproviders_grub:
-      repo:   "https://github.com/simp/augeasproviders_grub"
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_grub
     augeasproviders_ssh:
-      repo:   "https://github.com/simp/augeasproviders_ssh"
-      branch: 'simp-master'
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_ssh
+    compliance_markup:
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
     haveged:
-      repo:   "https://github.com/simp/puppet-haveged"
-      branch: 'simp-master'
-    iptables:              "https://github.com/simp/pupmod-simp-iptables"
-    pki:                   "https://github.com/simp/pupmod-simp-pki"
-    simpcat:               "https://github.com/simp/pupmod-simp-simpcat"
-    simplib:               "https://github.com/simp/pupmod-simp-simplib"
-    sssd:                  "https://github.com/simp/pupmod-simp-sssd"
+      branch: 5.X
+      repo: https://github.com/simp/puppet-haveged
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      branch: 5.X
+    pki:
+      repo: https://github.com/simp/pupmod-simp-pki
+      branch: 5.X
+    simpcat:
+      repo: https://github.com/simp/pupmod-simp-simpcat
+      branch: 5.X
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
+    sssd:
+      repo: https://github.com/simp/pupmod-simp-sssd
+      branch: 5.X
     stdlib:
-      repo:   "https://github.com/simp/puppetlabs-stdlib"
-      branch: 'simp-master'
-    tcpwrappers:           "https://github.com/simp/pupmod-simp-tcpwrappers"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
+    tcpwrappers:
+      repo: https://github.com/simp/pupmod-simp-tcpwrappers
+      branch: 5.X
   symlinks:
     ssh: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in ssh
