### PR TITLE
(SIMP-2665) Correct OpenSSH FIPS cipher-suite

### DIFF
--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -23,8 +23,9 @@ class ssh::client::params {
       'hmac-sha1'
     ]
     $fips_ciphers = [
-      'aes256-gcm@openssh.com',
-      'aes128-gcm@openssh.com'
+      'aes256-ctr',
+      'aes192-ctr',
+      'aes128-ctr'
     ]
   }
   else {
@@ -48,7 +49,10 @@ class ssh::client::params {
     ]
     $ciphers = [
       'aes256-gcm@openssh.com',
-      'aes128-gcm@openssh.com'
+      'aes128-gcm@openssh.com',
+      'aes256-ctr',
+      'aes192-ctr',
+      'aes128-ctr'
     ]
   }
   else {

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -25,7 +25,10 @@ class ssh::server::params {
   $_fallback_macs = [ 'hmac-sha1' ]
   $_primary_ciphers = [
     'aes256-gcm@openssh.com',
-    'aes128-gcm@openssh.com'
+    'aes128-gcm@openssh.com',
+    'aes256-ctr',
+    'aes192-ctr',
+    'aes128-ctr'
   ]
 
   if (
@@ -48,7 +51,11 @@ class ssh::server::params {
       'hmac-sha2-256',
       'hmac-sha1'
     ]
-    $fips_ciphers = $_primary_ciphers
+    $fips_ciphers = [
+      'aes256-ctr',
+      'aes192-ctr',
+      'aes128-ctr'
+    ]
   }
   else {
     # Don't know what OS this is so fall back to whatever should work with

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -29,8 +29,8 @@ describe 'ssh::server::conf' do
           it {
             if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
               (facts[:os][:release][:major].to_s >= '7')
-              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr',
-               'aes192-ctr', 'aes128-ctr' ]
+              expected_ciphers = ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com',
+                                  'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
               expected_macs = [ 'hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com',
                'hmac-sha2-512', 'hmac-sha2-256' ]
             else
@@ -98,8 +98,7 @@ describe 'ssh::server::conf' do
           it {
             if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
               (facts[:os][:release][:major].to_s >= '7')
-              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr',
-               'aes192-ctr', 'aes128-ctr' ]
+              expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
 
               expected_macs = [ 'hmac-sha2-256', 'hmac-sha1' ]
             else
@@ -121,8 +120,7 @@ describe 'ssh::server::conf' do
           it {
             if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
               (facts[:os][:release][:major].to_s >= '7')
-              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr',
-               'aes192-ctr', 'aes128-ctr' ]
+              expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
 
               expected_macs = [ 'hmac-sha2-256', 'hmac-sha1' ]
 
@@ -149,7 +147,8 @@ describe 'ssh::server::conf' do
           it {
             if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
               (facts[:os][:release][:major].to_s >= '7')
-              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com']
+              expected_ciphers = ['aes256-gcm@openssh.com', 'aes128-gcm@openssh.com',
+                                  'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
             else
               expected_ciphers = ['aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
             end

--- a/spec/defines/client/host_config_entry_spec.rb
+++ b/spec/defines/client/host_config_entry_spec.rb
@@ -20,7 +20,7 @@ describe 'ssh::client::host_config_entry' do
               (facts[:os][:release][:major].to_s >= '7')
               expected_macs = [ 'hmac-sha2-512-etm@openssh.com',
                 'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256' ]
-              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com' ]
+              expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com', 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
             else
               expected_macs = [ 'hmac-sha1' ]
               expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
@@ -222,7 +222,7 @@ EOM
               if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
                 (facts[:os][:release][:major].to_s >= '7')
                 expected_macs = [ 'hmac-sha2-256', 'hmac-sha1']
-                expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com' ]
+                expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
               else
                 expected_macs = [ 'hmac-sha1' ]
                 expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
@@ -256,7 +256,7 @@ EOM
               if (['RedHat', 'CentOS'].include?(facts[:os][:name])) and
                 (facts[:os][:release][:major].to_s >= '7')
                 expected_macs = [ 'hmac-sha2-256', 'hmac-sha1']
-                expected_ciphers = [ 'aes256-gcm@openssh.com', 'aes128-gcm@openssh.com' ]
+                expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]
               else
                 expected_macs = [ 'hmac-sha1' ]
                 expected_ciphers = [ 'aes256-ctr', 'aes192-ctr', 'aes128-ctr' ]


### PR DESCRIPTION
This patch corrects the `Ciphers` setting in `ssh_config` and
`sshd_config`, restricting the ciphers selcted to those approved under
the FIPS 140-2 certifications for Red Hat Enterprise Linux OpenSSH.
Prior to this, the cipher-suite erroniously included the unapproved
GCM-mode ciphers.

SIMP-2665 #close