### PR TITLE
Update conf.pp

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -311,7 +311,7 @@ class ssh::server::conf (
   }
 
   $subsystem_array = split($subsystem, ' +')
-  sshd_config_subsystem{ $subsystem_array[0]: command => $subsystem_array[1] }
+  sshd_config_subsystem{ $subsystem_array[0]: command => join(delete_at($subsytem_array,0),' ') }
 
   file { '/etc/ssh/local_keys':
     ensure  => 'directory',

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -311,7 +311,7 @@ class ssh::server::conf (
   }
 
   $subsystem_array = split($subsystem, ' +')
-  sshd_config_subsystem{ $subsystem_array[0]: command => join(delete_at($subsytem_array,0),' ') }
+  sshd_config_subsystem{ $subsystem_array[0]: command => join($subsystem_array[1..-1]) }
 
   file { '/etc/ssh/local_keys':
     ensure  => 'directory',

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -311,7 +311,7 @@ class ssh::server::conf (
   }
 
   $subsystem_array = split($subsystem, ' +')
-  sshd_config_subsystem{ $subsystem_array[0]: command => join($subsystem_array[1..-1]) }
+  sshd_config_subsystem{ $subsystem_array[0]: command => join($subsystem_array[1,-1]) }
 
   file { '/etc/ssh/local_keys':
     ensure  => 'directory',


### PR DESCRIPTION
When $subsystem contains a multiple word string only the first word will be passed to the subsystem configuration.
example: $subsystem="sftp a b c d"
will result in:
   Subsystem sftp a
not the desired
   Subsystem sftp a b c  d