### PR TITLE
(SIMP-2735) Set trusted_nets to ALL by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Thu Feb 233 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.1-0
 - Changed the default UsePrivilegeSeparation setting in sshd_config to use the
   vendor default of 'sandbox'
+- Changed the default value of simp_options::trusted_nets to ['ALL'] to prevent
+  permanent lockouts when a console isn't available.
 
 * Thu Jan 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated pki scheme, application certs now manged in

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -144,7 +144,7 @@ class ssh::server::conf (
   Boolean                          $pam                             = simplib::lookup('simp_options::pam', { 'default_value' => true }),
   Variant[Boolean,Enum['sandbox']] $useprivilegeseparation          = $::ssh::server::params::useprivilegeseparation,
   Boolean                          $x11forwarding                   = false,
-  Simplib::Netlist                 $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1', '::1'] }),
+  Simplib::Netlist                 $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['ALL'] }),
   Boolean                          $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Boolean                          $ldap                            = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
   Boolean                          $sssd                            = simplib::lookup('simp_options::sssd', { 'default_value' => false }),


### PR DESCRIPTION
- Changed the default value of simp_options::trusted_nets to ['ALL'] to prevent
  permanent lockouts when a console isn't available.

SIMP-2735 #close