### PR TITLE
(SIMP-2897) Revert ssh::server::conf::trusted_nets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
+* Thu Mar 23 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.0-0
+- Reverted 'ssh::server::conf::trusted_nets' to 'ALL' by default to prevent
+  lockouts from cloud systems
+
 * Mon Mar 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - move passgen to Puppet[:vardir]
 
 * Thu Mar 9 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 6.0.1-0
-- Remove some utf-8 smart quotes that were accidentally added to 
+- Remove some utf-8 smart quotes that were accidentally added to
   host_config_entry.pp
 
 * Thu Feb 23 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.1-0
@@ -12,7 +16,7 @@
   permanent lockouts when a console isn't available.
 
 * Thu Jan 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
-- Updated pki scheme, application certs now manged in
+- Updated pki scheme, application certs now managed in
   /etc/pki/simp_apps/sshd/x509
 
 * Tue Jan 10 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
@@ -24,7 +28,7 @@
 - Rename defined type ssh::client::add_entry to ssh::client::host_config_entry
 
 * Wed Nov 23 2016 Jeanne Greulich <jgreulich@onyxpoint.com> - 5.0.0-0
-- Fix dependancies for simp 6 bump
+- Fix dependencies for simp 6 bump
 
 * Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0-0
 - Updated to compliance_markup version 2
@@ -47,7 +51,7 @@
   if sssd is enabled.
 
 * Thu Aug 04 2016 Nick Miller <nick.miller@onyxpoint.com> - 4.1.9-0
-- Updated rpm requires to propery expire old versions
+- Updated rpm requires to properly expire old versions
 
 * Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.8-0
 - Migration to semantic versioning and fix of the build system

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -144,7 +144,7 @@ class ssh::server::conf (
   Boolean                          $pam                             = simplib::lookup('simp_options::pam', { 'default_value' => true }),
   Variant[Boolean,Enum['sandbox']] $useprivilegeseparation          = $::ssh::server::params::useprivilegeseparation,
   Boolean                          $x11forwarding                   = false,
-  Simplib::Netlist                 $trusted_nets                    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['ALL'] }),
+  Simplib::Netlist                 $trusted_nets                    = ['ALL'],
   Boolean                          $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Boolean                          $ldap                            = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
   Boolean                          $sssd                            = simplib::lookup('simp_options::sssd', { 'default_value' => false }),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
The trusted_nets option has been reverted to 'ALL' since the more
common use case is to install on a virtual machine in one of the
popular cloud infrastructures.

If you do this, then the default of 'simp_options::trusted_nets' is
wrong 100% of the time.

SIMP-2897 #comment Reverted trusted_nets setting
SIMP-2904 #close