### PR TITLE
(SIMP-2940) Unnecessary permission changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Mar 28 2017 Nicholas Hughes - 6.1.0-0
+- Set permissions back to what the RPM sets and security scans expect
+  - /etc/ssh/moduli
+  - /var/empty/sshd
+  - /var/empty/sshd/etc
+  - /var/empty/sshd/etc/localtime
+
 * Thu Mar 23 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.0-0
 - Reverted 'ssh::server::conf::trusted_nets' to 'ALL' by default to prevent
   lockouts from cloud systems

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,7 @@ class ssh::server {
   file { '/etc/ssh/moduli':
     owner => 'root',
     group => 'root',
-    mode  => '0600'
+    mode  => '0644'
   }
 
   file { '/etc/ssh/ssh_host_dsa_key':
@@ -50,7 +50,7 @@ class ssh::server {
     ensure  => 'directory',
     owner   => 'root',
     group   => 'root',
-    mode    => '0744',
+    mode    => '0711',
     require => Package['openssh-server'],
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -58,12 +58,15 @@ class ssh::server {
     ensure  => 'directory',
     owner   => 'root',
     group   => 'root',
-    mode    => '0755',
+    mode    => '0711',
     require => Package['openssh-server']
   }
 
   file { '/var/empty/sshd/etc/localtime':
     source  => '/etc/localtime',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
     force   => true,
     require => Package['openssh-server']
   }


### PR DESCRIPTION
https://simp-project.atlassian.net/browse/SIMP-2940

The module change the following permissions from the RPM default, which triggers on some security scans. Since security is not enhanced by the changes, it is recommended to leave them at RPM default.

*Set /etc/ssh/moduli permissions to ‘0644’ instead of ‘0600’*
https://bugzilla.redhat.com/show_bug.cgi?id=1043661

*Set /var/empty/sshd to '0711' instead of '0744'*
This actually makes more sense since you'd need to traverse the directory to read the files within.