### PR TITLE
(SIMP-3613) ssh: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.1-0
+- Update concat version in metadata.json & build/rpm_metadata/requires
+
 * Tue Jun 20 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.0-0
 - Convert internally-used Puppet 3 functions to Puppet 4
   - ssh_config_bool_translate is now ssh::config_bool_translate

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -7,7 +7,7 @@ Requires: pupmod-herculesteam-augeasproviders_grub < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1-0
 Requires: pupmod-herculesteam-augeasproviders_ssh < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_ssh >= 2.5.0-0
-Requires: pupmod-puppetlabs-concat < 3.0.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -46,7 +46,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
concat 3.0.0 is fully backward compatible with 2.x.