### PR TITLE
(SIMP-3613) ssh: Pin concat to 3.0.0 in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,10 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
-    concat: https://github.com/simp/puppetlabs-concat
+    concat:
+      # master is at 4.0.1, but we are bound to < 4.0.0 in our metadata.json
+      repo: https://github.com/simp/puppetlabs-concat
+      ref: 3.0.0
     haveged:
       repo: https://github.com/simp/puppet-haveged
       branch: simp-master


### PR DESCRIPTION
Pin concat to 3.0.0 in .fixtures.yml, as metadata.json bounds
concat to < 4.0.0.