### PR TITLE
(SIMP-4679) Flip to Hiera v5 for testing

### DIFF
--- a/spec/acceptance/suites/compliance/00_default_spec.rb
+++ b/spec/acceptance/suites/compliance/00_default_spec.rb
@@ -36,6 +36,8 @@ describe 'ssh STIG enforcement' do
   let(:hieradata) { <<-EOF
 ---
 ssh::server::conf::app_pki_external_source: '/etc/pki/simp-testing/pki'
+# This is for Beaker
+ssh::server::conf::permitrootlogin: true
 compliance_markup::enforcement:
   - disa_stig
   EOF
@@ -55,16 +57,15 @@ compliance_markup::enforcement:
     context 'when enforcing the STIG' do
       let(:hiera_yaml) { <<-EOM
 ---
-:backends:
-  - yaml
-  - simp_compliance_enforcement
-:yaml:
-  :datadir: "#{hiera_datadir(host)}"
-:simp_compliance_enforcement:
-  :datadir: "#{hiera_datadir(host)}"
-:hierarchy:
-  - default
-:logger: console
+version: 5
+hierarchy:
+  - name: Common
+    path: default.yaml
+  - name: Compliance
+    lookup_key: compliance_markup::enforcement
+defaults:
+  data_hash: yaml_data
+  datadir: "#{hiera_datadir(host)}"
   EOM
       }
 

--- a/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
+++ b/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
@@ -1,6 +1,7 @@
 skips = {
   'V-72257' => 'HostbasedAuthentication is set to NO so the keys are not used.',
-  'V-72225' => 'Skipping the check of the banner. '
+  'V-72225' => 'Skipping the check of the banner.',
+  'V-72247' => 'Beaker requires root SSH access to run, this is disabled by default.'
 }
 overrides = []
 subsystems = [ 'ssh' ]


### PR DESCRIPTION
Something in Puppet 4.10.4+ broke the Hiera v3 backend for the
compliance engine so we've swtiched our compliance testing over to Hiera
v5