### PR TITLE
(SIMP-5718) sshd RhostsRSAAuthentication error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Aug 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.3-0
+- By default, do not specify the obsolete RhostsRSAAuthentication
+  configuration parameter in sshd_config on systems running openssh 7.4
+  or later.  Beginning with openshh 7.4, sshd emits an error message when
+  this parameter is present in sshd_config.
+
 * Thu May 03 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.4.2-0
 - Added some variables for sshd_config to meet STIG requirements.
   Most are just confirmation of defaults with the exception of

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -137,6 +137,14 @@ class ssh::server::params {
     $useprivilegeseparation = 'sandbox'
   }
 
+  # This setting is only present in old openssh versions
+  if versioncmp($facts['openssh_version'], '7.4') >= 0 {
+    $rhostsrsaauthentication = undef
+  }
+  else {
+    $rhostsrsaauthentication = false
+  }
+
   # If the host is configured to use IPA, enable this setting
   if $facts['ipa'] {
     $gssapiauthentication = true

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -273,6 +273,23 @@ describe 'ssh::server::conf' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_sshd_config('GSSAPIAuthentication').with_value('yes') }
         end
+
+        context 'with default parameters, openssh_version=7.4' do
+          let(:facts) { os_facts.merge( { :openssh_version => '7.4'} ) }
+          let(:pre_condition){ 'include "::ssh"' }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not contain_sshd_config('RhostsRSAAuthentication') }
+        end
+
+        context 'with rhostsrsaauthentication explicitly disabled, openssh_version=7.4' do
+          let(:facts) { os_facts.merge( { :openssh_version => '7.4'} ) }
+          let(:hieradata) { 'rhostsrsaauthentication_disabled' }
+          let(:pre_condition){ 'include "::ssh"' }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_sshd_config('RhostsRSAAuthentication').with_value('no') }
+        end
       end
     end
   end

--- a/spec/fixtures/hieradata/rhostsrsaauthentication_disabled.yaml
+++ b/spec/fixtures/hieradata/rhostsrsaauthentication_disabled.yaml
@@ -1,0 +1,2 @@
+---
+ssh::server::conf::rhostsrsaauthentication: false


### PR DESCRIPTION
By default, do not configure RhostsRSAAuthentication in sshd_config for
versions of openssh that no longer allow that option (openssh 7.4 and
greater).  The user can still configure this option to match the
outdated STIG checks, but, sshd will emit an error message when
it parses its configuraton file.

SIMP-5718 # close