### PR TITLE
(SIMP-5429) Delete fewer keys in default acceptance test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Oct 11 2018 Zach <turtles.be.the.best@gmail.com> - 6.4.5-0
+- Altered 00_default_spec.rb to stop deleting all ssh keys in test
+- Replaced puppet_environment with puppet_collection in nodesets
+
 * Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.4.5-0
 - Updated $app_pki_external_source to accept any string. This matches the
   functionality of pki::copy.

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -43,6 +43,6 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
-<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
-  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
+  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -43,6 +43,6 @@ CONFIG:
   log_level:       verbose
   type:            aio
   vagrant_memsize: 256
-<% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
-  puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
+<% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
+  puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -149,7 +149,7 @@ describe 'ssh class' do
           on(hosts, 'echo password | passwd testuser --stdin')
           on(hosts, 'chage -d 0 testuser')
           # remove publc key from server
-          on(server, 'rm -rf /etc/ssh/local_keys/*')
+          on(server, 'rm -f /etc/ssh/local_keys/testuser')
 
           on(client, '/usr/local/bin/ssh_test_script_change_pass testuser ' \
                      "#{os}-server password correcthorsebatterystaple")


### PR DESCRIPTION
Altered 00_default_spec.rb to stop deleting all ssh keys in test
Replaced puppet_environment with puppet_collection in nodesets

SIMP-5429 #close 