### PR TITLE
(SIMP-5825) SSH subsystem error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Tue Dec 04 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.6.0-0
-- Patch to add space when joining back the elements of command.
-
+- Fix bug in which the sshd 'Subsystem' configuration specified by 
+  ssh::server::conf::subsystem was erroneously stripped of whitespace
+  
 * Thu Nov 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.6.0-0
 - Added a new class, ssh::authorized_keys, that consumes a hash of ssh pubkeys
   - Users are meant to be able to paste the output of their pubkey into hiera

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Dec 04 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.6.0-0
+- Patch to add space when joining back the elements of command.
+
 * Thu Nov 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.6.0-0
 - Added a new class, ssh::authorized_keys, that consumes a hash of ssh pubkeys
   - Users are meant to be able to paste the output of their pubkey into hiera

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -350,7 +350,7 @@ class ssh::server::conf (
   }
 
   $subsystem_array = split($subsystem, ' +')
-  sshd_config_subsystem { $subsystem_array[0]: command => join($subsystem_array[1,-1]) }
+  sshd_config_subsystem { $subsystem_array[0]: command => join($subsystem_array[1,-1], " ") }
 
   file { '/etc/ssh/local_keys':
     ensure  => 'directory',


### PR DESCRIPTION
 - Add a space when joining back together the elements of command.

SIMP-5825 #close