### PR TITLE
(SIMP-5324) Add TOTP support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,14 +9,15 @@ fixtures:
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
+    oath: https://github.com/simp/pupmod-simp-oath
+    oddjob: https://github.com/simp/pupmod-simp-oddjob
+    pam: https://github.com/simp/pupmod-simp-pam
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog
     simplib: https://github.com/simp/pupmod-simp-simplib
     sssd: https://github.com/simp/pupmod-simp-sssd
     stdlib: https://github.com/simp/puppetlabs-stdlib
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
-    oath: https://github.com/simp/pupmod-simp-oath
-    pam: https://github.com/simp/pupmod-simp-pam
     sshkeys_core:
       repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
       puppet_version: ">= 6.0.0"
@@ -24,10 +25,5 @@ fixtures:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch:  master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles
-
-    # Required for the acceptance test
-    sshkeys_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
-      puppet_version: ">= 6.0.0"
   symlinks:
     ssh: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,6 +15,8 @@ fixtures:
     sssd: https://github.com/simp/pupmod-simp-sssd
     stdlib: https://github.com/simp/puppetlabs-stdlib
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
+    oath: https://github.com/simp/pupmod-simp-oath
+    pam: https://github.com/simp/pupmod-simp-pam
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch:  master

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,6 +17,9 @@ fixtures:
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
     oath: https://github.com/simp/pupmod-simp-oath
     pam: https://github.com/simp/pupmod-simp-pam
+    sshkeys_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
+      puppet_version: ">= 6.0.0"
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch:  master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Apr 16 2019 Zach <turtles.be.the.best@gmail.com> - 6.7.0-0
+- Add OATH support
+
 * Thu Apr 11 2019 Bob Vincent <pillarsdotnet@gmail.com> - 6.7.0
 - Added support for the following SSH server configuration parameters:
   - AllowGroups

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Tue Apr 16 2019 Zach <turtles.be.the.best@gmail.com> - 6.7.0-0
 - Add OATH support
 
-* Thu Apr 11 2019 Bob Vincent <pillarsdotnet@gmail.com> - 6.7.0
+* Thu Apr 11 2019 Bob Vincent <pillarsdotnet@gmail.com> - 6.7.0-0
 - Added support for the following SSH server configuration parameters:
   - AllowGroups
   - AllowUsers

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.13')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.14.1', '< 2.0.0'])
 end

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ If you need to customize a setting in `/etc/ssh/ssh_config` that
 
 ```puppet
 # RequestTTY isn't handled by ssh::client::host_config_entry
+# Note: RequestTTY is not a valid ssh_config setting on OpenSSH where version < 5.9
 ssh_config { 'Global RequestTTY':
   ensure => present,
   key    => 'RequestTTY',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 * [`ssh::client`](#sshclient): Sets up a ssh client and creates /etc/ssh/ssh_config.
 * [`ssh::client::params`](#sshclientparams): Default parameters for the SSH client
 * [`ssh::server`](#sshserver): Sets up a ssh server and starts sshd.
-* [`ssh::server::conf`](#sshserverconf): Sets up sshd_config and adds an iptables rule if iptables is being used.  sshd configuration variables can be set using Augeas outside of thi
+* [`ssh::server::conf`](#sshserverconf): 
 * [`ssh::server::params`](#sshserverparams): Default parameters for the SSH Server  KexAlgorithm configuration was not added until openssh 5.7 Curve exchange was not fully supported unti
 
 **Defined types**
@@ -176,10 +176,7 @@ Default value: simplib::lookup('simp_options::package_ensure', { 'default_value'
 
 ### ssh::server::conf
 
-Sets up sshd_config and adds an iptables rule if iptables is being used.
-
-sshd configuration variables can be set using Augeas outside of this class
-with no adverse effects.
+The ssh::server::conf class.
 
 #### Parameters
 
@@ -189,17 +186,31 @@ The following parameters are available in the `ssh::server::conf` class.
 
 Data type: `Array[String]`
 
-Specifies what environment variables sent by the
-client will be copied into the sessions environment.
 
-Default value: $::ssh::server::params::acceptenv
+
+Default value: $ssh::server::params::acceptenv
+
+##### `allowgroups`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
+
+##### `allowusers`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
 
 ##### `authorizedkeysfile`
 
 Data type: `String`
 
-This is set to a non-standard location to
-provide for increased control over who can log in as a given user.
+
 
 Default value: '/etc/ssh/local_keys/%u'
 
@@ -207,8 +218,7 @@ Default value: '/etc/ssh/local_keys/%u'
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
-Specifies a program to be used for
-lookup of the user's public keys.
+
 
 Default value: `undef`
 
@@ -216,8 +226,7 @@ Default value: `undef`
 
 Data type: `String`
 
-Specifies the user under whose
-account the AuthorizedKeysCommand is run.
+
 
 Default value: 'nobody'
 
@@ -225,8 +234,7 @@ Default value: 'nobody'
 
 Data type: `Stdlib::Absolutepath`
 
-The contents of the specified file are sent to the
-remote user before authentication is allowed.
+
 
 Default value: '/etc/issue.net'
 
@@ -234,8 +242,7 @@ Default value: '/etc/issue.net'
 
 Data type: `Boolean`
 
-Specifies whether
-challenge-response authentication is allowed.
+
 
 Default value: `false`
 
@@ -243,272 +250,15 @@ Default value: `false`
 
 Data type: `Optional[Array[String]]`
 
-Specifies the ciphers allowed for protocol
-version 2.  When unset, a strong set of ciphers is automatically
-selected by this class, taking into account whether the server is
-in FIPS mode.
+
 
 Default value: `undef`
-
-##### `compression`
-
-Data type: `Variant[Boolean,Enum['delayed']]`
-
-Specifies whether compression is allowed, or
-delayed until the user has authenticated successfully.
-
-Default value: 'delayed'
-
-##### `fallback_ciphers`
-
-Data type: `Array[String]`
-
-The set of ciphers that should be used should
-no other cipher be declared. This is used when
-$::ssh::server::conf::enable_fallback_ciphers is enabled.
-
-Default value: $::ssh::server::params::fallback_ciphers
-
-##### `enable_fallback_ciphers`
-
-Data type: `Boolean`
-
-If true, add the fallback ciphers
-from ssh::server::params to the cipher list. This is intended to provide
-compatibility with non-SIMP systems in a way that properly supports FIPS
-140-2.
-
-Default value: `true`
-
-##### `syslogfacility`
-
-Data type: `Ssh::Syslogfacility`
-
-Gives the facility code that is used when
-logging messages.
-
-Default value: 'AUTHPRIV'
-
-##### `gssapiauthentication`
-
-Data type: `Boolean`
-
-Specifies whether user authentication
-based on GSSAPI is allowed. If the system is connected to an IPA domain,
-this will be default to true, based on the existance of the `ipa` fact.
-
-Default value: $::ssh::server::params::gssapiauthentication
-
-##### `kex_algorithms`
-
-Data type: `Optional[Array[String]]`
-
-Specifies the key exchange algorithms accepted.  When
-unset, an appropriate set of algorithms is automatically selected by this
-class, taking into account whether the server is in FIPS mode and whether
-the version of openssh installed supports this feature.
-
-Default value: `undef`
-
-##### `listenaddress`
-
-Data type: `Simplib::Host`
-
-Specifies the local addresses sshd should listen on.
-
-Default value: '0.0.0.0'
-
-##### `port`
-
-Data type: `Simplib::Port`
-
-Specifies the port number SSHD listens on.
-
-Default value: 22
-
-##### `macs`
-
-Data type: `Optional[Array[String]]`
-
-Specifies the available MAC algorithms. When unset, a
-strong set of ciphers is automatically selected by this class, taking into
-account whether the server is in FIPS mode.
-
-Default value: `undef`
-
-##### `passwordauthentication`
-
-Data type: `Optional[Boolean]`
-
-Enable password authentication on the sshd
-server. If left as undef (default), this setting will not be managed.
-
-Default value: `undef`
-
-##### `permitemptypasswords`
-
-Data type: `Boolean`
-
-When password authentication is allowed,
-it specifies whether the server allows login to accounts with empty password
-strings.
-
-Default value: `false`
-
-##### `permitrootlogin`
-
-Data type: `Ssh::PermitRootLogin`
-
-Specifies whether root can log in using SSH.
-
-Default value: `false`
-
-##### `printlastlog`
-
-Data type: `Boolean`
-
-Specifies whether SSHD should print the date and
-time of the last user login when a user logs in interactively.
-
-Default value: `false`
-
-##### `subsystem`
-
-Data type: `String`
-
-Configures and external subsystem for file
-transfers.
-
-Default value: 'sftp /usr/libexec/openssh/sftp-server'
-
-##### `pam`
-
-Data type: `Boolean`
-
-Enables the Pluggable Authentication Module interface.
-
-Default value: simplib::lookup('simp_options::pam', { 'default_value' => true })
-
-##### `useprivilegeseparation`
-
-Data type: `Variant[Boolean,Enum['sandbox']]`
-
-Specifies whether sshd separates
-privileges by creating an unprivileged child process to deal with incoming
-network traffic.
-
-Default value: $::ssh::server::params::useprivilegeseparation
-
-##### `x11forwarding`
-
-Data type: `Boolean`
-
-Specifies whether X11 forwarding is permitted.
-
-Default value: `false`
-
-##### `trusted_nets`
-
-Data type: `Simplib::Netlist`
-
-The networks to allow to connect to SSH.
-
-Default value: ['ALL']
-
-##### `firewall`
-
-Data type: `Boolean`
-
-If true, use the SIMP iptables class.
-
-Default value: simplib::lookup('simp_options::firewall', { 'default_value' => false })
-
-##### `ldap`
-
-Data type: `Boolean`
-
-If true, enable LDAP support on the system. If
-authorizedkeyscommand is empty, this will set the authorizedkeyscommand to
-ssh-ldap-wrapper so that SSH public keys can be stored directly in LDAP.
-
-Default value: simplib::lookup('simp_options::ldap', { 'default_value' => false })
-
-##### `tcpwrappers`
-
-Data type: `Boolean`
-
-If true, allow sshd tcpwrapper.
-
-Default value: simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
-
-##### `haveged`
-
-Data type: `Boolean`
-
-If true, include the haveged module to assist
-with entropy generation.
-
-Default value: simplib::lookup('simp_options::haveged', { 'default_value' => false })
-
-##### `sssd`
-
-Data type: `Boolean`
-
-If true, use sssd.
-
-Default value: simplib::lookup('simp_options::sssd', { 'default_value' => false })
-
-##### `fips`
-
-Data type: `Boolean`
-
-If set or FIPS is already enabled, adjust for FIPS mode.
-
-Default value: simplib::lookup('simp_options::fips', { 'default_value' => false })
-
-##### `pki`
-
-Data type: `Variant[Enum['simp'],Boolean]`
-
-* If 'simp', include SIMP's pki module and use pki::copy to manage
-  application certs in /etc/pki/simp_apps/sshd/x509
-* If true, do *not* include SIMP's pki module, but still use pki::copy
-  to manage certs in /etc/pki/simp_apps/sshd/x509
-* If false, do not include SIMP's pki module and do not use pki::copy
-  to manage certs.  You will need to appropriately assign a subset of:
-  * app_pki_dir
-  * app_pki_key
-  * app_pki_cert
-  * app_pki_ca
-  * app_pki_ca_dir
-
-Default value: simplib::lookup('simp_options::pki', { 'default_value' => false })
-
-##### `app_pki_external_source`
-
-Data type: `String`
-
-* If pki = 'simp' or true, this is the directory from which certs will be
-  copied, via pki::copy.  Defaults to /etc/pki/simp/x509.
-
-* If pki = false, this variable has no effect.
-
-Default value: simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' })
-
-##### `app_pki_key`
-
-Data type: `Stdlib::Absolutepath`
-
-Path and name of the private SSL key file. This key file is used to generate
-the system SSH certificates for consistency.
-
-Default value: "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem"
 
 ##### `clientalivecountmax`
 
 Data type: `Integer`
 
-@see man page for sshd_config
+
 
 Default value: 0
 
@@ -516,15 +266,47 @@ Default value: 0
 
 Data type: `Integer`
 
-@see man page for sshd_config
+
 
 Default value: 600
+
+##### `compression`
+
+Data type: `Variant[Boolean,Enum['delayed']]`
+
+
+
+Default value: 'delayed'
+
+##### `denygroups`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
+
+##### `denyusers`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
+
+##### `gssapiauthentication`
+
+Data type: `Boolean`
+
+
+
+Default value: $ssh::server::params::gssapiauthentication
 
 ##### `hostbasedauthentication`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
 
 Default value: `false`
 
@@ -532,7 +314,7 @@ Default value: `false`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
 
 Default value: `true`
 
@@ -540,7 +322,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
 
 Default value: `true`
 
@@ -548,7 +330,87 @@ Default value: `true`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
+
+Default value: `false`
+
+##### `kex_algorithms`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
+
+##### `listenaddress`
+
+Data type: `Simplib::Host`
+
+
+
+Default value: '0.0.0.0'
+
+##### `logingracetime`
+
+Data type: `Integer[0]`
+
+
+
+Default value: 120
+
+##### `ssh_loglevel`
+
+Data type: `Optional[Ssh::Loglevel]`
+
+
+
+Default value: `undef`
+
+##### `macs`
+
+Data type: `Optional[Array[String]]`
+
+
+
+Default value: `undef`
+
+##### `maxauthtries`
+
+Data type: `Integer[1]`
+
+
+
+Default value: 6
+
+##### `usepam`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::pam', { 'default_value' => true })
+
+##### `passwordauthentication`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
+
+##### `permitemptypasswords`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### `permitrootlogin`
+
+Data type: `Ssh::PermitRootLogin`
+
+
 
 Default value: `false`
 
@@ -556,7 +418,23 @@ Default value: `false`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
+
+Default value: `false`
+
+##### `port`
+
+Data type: `Simplib::Port`
+
+
+
+Default value: 22
+
+##### `printlastlog`
+
+Data type: `Boolean`
+
+
 
 Default value: `false`
 
@@ -564,7 +442,7 @@ Default value: `false`
 
 Data type: `Array[Integer[1,2]]`
 
-@see man page for sshd_config
+
 
 Default value: [2]
 
@@ -572,21 +450,169 @@ Default value: [2]
 
 Data type: `Optional[Boolean]`
 
-This sshd option has been completely removed in openssh 7.4 and
-will cause an error message to be logged, when present.  On systems
-using openssh 7.4 or later, only set this value if you need
-`RhostsRSAAuthentication` to be in the sshd configuration file to
-satisfy an outdated, STIG check.
 
-Default value: $::ssh::server::params::rhostsrsaauthentication
+
+Default value: $ssh::server::params::rhostsrsaauthentication
 
 ##### `strictmodes`
 
 Data type: `Boolean`
 
-@see man page for sshd_config
+
 
 Default value: `true`
+
+##### `subsystem`
+
+Data type: `String`
+
+
+
+Default value: 'sftp /usr/libexec/openssh/sftp-server'
+
+##### `syslogfacility`
+
+Data type: `Ssh::Syslogfacility`
+
+
+
+Default value: 'AUTHPRIV'
+
+##### `tcpwrappers`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
+
+##### `useprivilegeseparation`
+
+Data type: `Variant[Boolean,Enum['sandbox']]`
+
+
+
+Default value: $ssh::server::params::useprivilegeseparation
+
+##### `x11forwarding`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### `app_pki_external_source`
+
+Data type: `String`
+
+
+
+Default value: simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' })
+
+##### `app_pki_key`
+
+Data type: `Stdlib::Absolutepath`
+
+
+
+Default value: "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem"
+
+##### `enable_fallback_ciphers`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
+
+##### `fallback_ciphers`
+
+Data type: `Array[String]`
+
+
+
+Default value: $ssh::server::params::fallback_ciphers
+
+##### `fips`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::fips', { 'default_value' => false })
+
+##### `firewall`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::firewall', { 'default_value' => false })
+
+##### `haveged`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::haveged', { 'default_value' => false })
+
+##### `ldap`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::ldap', { 'default_value' => false })
+
+##### `oath`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::oath', { 'default_value' => false })
+
+##### `manage_pam_sshd`
+
+Data type: `Boolean`
+
+
+
+Default value: $oath
+
+##### `oath_window`
+
+Data type: `Integer[0]`
+
+
+
+Default value: 1
+
+##### `pki`
+
+Data type: `Variant[Enum['simp'],Boolean]`
+
+
+
+Default value: simplib::lookup('simp_options::pki', { 'default_value' => false })
+
+##### `sssd`
+
+Data type: `Boolean`
+
+
+
+Default value: simplib::lookup('simp_options::sssd', { 'default_value' => false })
+
+##### `trusted_nets`
+
+Data type: `Simplib::Netlist`
+
+
+
+Default value: ['ALL']
 
 ### ssh::server::params
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,16 +6,16 @@
 **Classes**
 
 * [`ssh`](#ssh): Sets up files for ssh.
-* [`ssh::authorized_keys`](#sshauthorized_keys): Add `ssh_authorized_keys` via hiera in a loop  It was designed so you can just paste the output of the ssh pubkey into hiera and it will work
+* [`ssh::authorized_keys`](#sshauthorized_keys): Add `ssh_authorized_keys` via hiera in a loop
 * [`ssh::client`](#sshclient): Sets up a ssh client and creates /etc/ssh/ssh_config.
 * [`ssh::client::params`](#sshclientparams): Default parameters for the SSH client
 * [`ssh::server`](#sshserver): Sets up a ssh server and starts sshd.
-* [`ssh::server::conf`](#sshserverconf): 
-* [`ssh::server::params`](#sshserverparams): Default parameters for the SSH Server  KexAlgorithm configuration was not added until openssh 5.7 Curve exchange was not fully supported unti
+* [`ssh::server::conf`](#sshserverconf): Sets up sshd_config and adds an iptables rule if iptables is being used.
+* [`ssh::server::params`](#sshserverparams): Default parameters for the SSH Server
 
 **Defined types**
 
-* [`ssh::client::host_config_entry`](#sshclienthost_config_entry): Creates a host entry to ssh_config  GSSAPI may be used.  the client's GSSAPI credentials will force the rekeying of the ssh connection.  trus
+* [`ssh::client::host_config_entry`](#sshclienthost_config_entry): Creates a host entry to ssh_config
 
 **Resource types**
 
@@ -23,13 +23,13 @@
 
 **Functions**
 
-* [`ssh::autokey`](#sshautokey): This function generates a random RSA SSH private and public key pair for a passed user.  Keys are stored in    "Puppet[:vardir]/simp/environm
-* [`ssh::config_bool_translate`](#sshconfig_bool_translate): Translates true|false or 'true'|'false' to 'yes'|'no', respectively All other values are passed-through unchanged
-* [`ssh::format_host_entry_for_sorting`](#sshformat_host_entry_for_sorting): A method to sensibly format sort SSH 'host' entries which contain wildcards and question marks.  The output is intended for use with the simp
-* [`ssh::global_known_hosts`](#sshglobal_known_hosts): Update the ssh_known_hosts files for all hosts, purging old files, removing duplicates, and creating catalog resources that are found   Note:
+* [`ssh::autokey`](#sshautokey): Generates a random RSA SSH private and public key pair for a passed
+* [`ssh::config_bool_translate`](#sshconfig_bool_translate): Translates true|false or 'true'|'false' to 'yes'|'no', respectively
+* [`ssh::format_host_entry_for_sorting`](#sshformat_host_entry_for_sorting): A method to sensibly format sort SSH 'host' entries which contain
+* [`ssh::global_known_hosts`](#sshglobal_known_hosts): Update the ssh_known_hosts files for all hosts, purging old files,
 * [`ssh::parse_ssh_pubkey`](#sshparse_ssh_pubkey): Taka an ssh pugkey that looks like:   ssh-rsa jdlkfgjsdfo;i... user@domain.com and turn it into a hash, usable in the ssh_authorized_key type
-* [`ssh_autokey`](#ssh_autokey): This function generates a random RSA SSH private and public key pair for a passed user.  Keys are stored in "Puppet[:vardir]/simp/environment
-* [`ssh_global_known_hosts`](#ssh_global_known_hosts): DEPRECATED: This function updates the ssh_known_hosts file for all hosts and updates any new ones that are found.\nThis function takes one ar
+* [`ssh_autokey`](#ssh_autokey): Generates a random RSA SSH private and public key pair for a passed user.
+* [`ssh_global_known_hosts`](#ssh_global_known_hosts): **DEPRECATED**
 
 ## Classes
 
@@ -59,9 +59,7 @@ Default value: `true`
 
 ### ssh::authorized_keys
 
-Add `ssh_authorized_keys` via hiera in a loop
-
-It was designed so you can just paste the output of the ssh pubkey into
+This class was designed so you can just paste the output of the ssh pubkey into
 hiera and it will work. See the example below for details.
 
 > **WARNING**
@@ -176,7 +174,12 @@ Default value: simplib::lookup('simp_options::package_ensure', { 'default_value'
 
 ### ssh::server::conf
 
-The ssh::server::conf class.
+``sshd`` configuration variables can be set using Augeas outside of this
+class with no adverse effects.
+
+SSH Parameters ####
+
+SIMP parameters ####
 
 #### Parameters
 
@@ -186,7 +189,8 @@ The following parameters are available in the `ssh::server::conf` class.
 
 Data type: `Array[String]`
 
-
+Specifies what environment variables sent by the
+client will be copied into the sessions environment.
 
 Default value: $ssh::server::params::acceptenv
 
@@ -194,7 +198,9 @@ Default value: $ssh::server::params::acceptenv
 
 Data type: `Optional[Array[String]]`
 
-
+A list of group name patterns. If specified, login is
+allowed only for users whose primary or supplementary group list matches
+one of the patterns.
 
 Default value: `undef`
 
@@ -202,7 +208,8 @@ Default value: `undef`
 
 Data type: `Optional[Array[String]]`
 
-
+A list of user name patterns. If specified, login is
+allowed only for users whose name matches one of the patterns.
 
 Default value: `undef`
 
@@ -210,7 +217,8 @@ Default value: `undef`
 
 Data type: `String`
 
-
+This is set to a non-standard location to
+provide for increased control over who can log in as a given user.
 
 Default value: '/etc/ssh/local_keys/%u'
 
@@ -218,7 +226,8 @@ Default value: '/etc/ssh/local_keys/%u'
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
-
+Specifies a program to be used for
+lookup of the user's public keys.
 
 Default value: `undef`
 
@@ -226,7 +235,8 @@ Default value: `undef`
 
 Data type: `String`
 
-
+Specifies the user under whose
+account the AuthorizedKeysCommand is run.
 
 Default value: 'nobody'
 
@@ -234,7 +244,8 @@ Default value: 'nobody'
 
 Data type: `Stdlib::Absolutepath`
 
-
+The contents of the specified file are sent to the
+remote user before authentication is allowed.
 
 Default value: '/etc/issue.net'
 
@@ -242,7 +253,8 @@ Default value: '/etc/issue.net'
 
 Data type: `Boolean`
 
-
+Specifies whether
+challenge-response authentication is allowed.
 
 Default value: `false`
 
@@ -250,7 +262,10 @@ Default value: `false`
 
 Data type: `Optional[Array[String]]`
 
-
+Specifies the ciphers allowed for protocol
+version 2.  When unset, a strong set of ciphers is automatically
+selected by this class, taking into account whether the server is
+in FIPS mode.
 
 Default value: `undef`
 
@@ -258,7 +273,7 @@ Default value: `undef`
 
 Data type: `Integer`
 
-
+@see man page for sshd_config
 
 Default value: 0
 
@@ -266,7 +281,7 @@ Default value: 0
 
 Data type: `Integer`
 
-
+@see man page for sshd_config
 
 Default value: 600
 
@@ -274,7 +289,8 @@ Default value: 600
 
 Data type: `Variant[Boolean,Enum['delayed']]`
 
-
+Specifies whether compression is allowed, or
+delayed until the user has authenticated successfully.
 
 Default value: 'delayed'
 
@@ -282,7 +298,9 @@ Default value: 'delayed'
 
 Data type: `Optional[Array[String]]`
 
-
+A list of group name patterns.  If specified, login is
+disallowed for users whose primary or supplementary group list matches
+one of the patterns.
 
 Default value: `undef`
 
@@ -290,7 +308,8 @@ Default value: `undef`
 
 Data type: `Optional[Array[String]]`
 
-
+A list of user name patterns.  If specified, login is
+disallowed for users whose name matches one of the patterns.
 
 Default value: `undef`
 
@@ -298,7 +317,9 @@ Default value: `undef`
 
 Data type: `Boolean`
 
-
+Specifies whether user authentication
+based on GSSAPI is allowed. If the system is connected to an IPA domain,
+this will be default to true, based on the existance of the `ipa` fact.
 
 Default value: $ssh::server::params::gssapiauthentication
 
@@ -306,7 +327,7 @@ Default value: $ssh::server::params::gssapiauthentication
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `false`
 
@@ -314,7 +335,7 @@ Default value: `false`
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `true`
 
@@ -322,7 +343,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `true`
 
@@ -330,7 +351,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `false`
 
@@ -338,7 +359,10 @@ Default value: `false`
 
 Data type: `Optional[Array[String]]`
 
-
+Specifies the key exchange algorithms accepted.  When
+unset, an appropriate set of algorithms is automatically selected by this
+class, taking into account whether the server is in FIPS mode and whether
+the version of openssh installed supports this feature.
 
 Default value: `undef`
 
@@ -346,7 +370,7 @@ Default value: `undef`
 
 Data type: `Simplib::Host`
 
-
+Specifies the local addresses sshd should listen on.
 
 Default value: '0.0.0.0'
 
@@ -354,7 +378,9 @@ Default value: '0.0.0.0'
 
 Data type: `Integer[0]`
 
-
+The max number of seconds the server will wait for a
+successful login before disconnecting. If the value is 0, there is no
+limit.
 
 Default value: 120
 
@@ -362,7 +388,8 @@ Default value: 120
 
 Data type: `Optional[Ssh::Loglevel]`
 
-
+Specifies the verbosity level that is used when logging
+messages from sshd.
 
 Default value: `undef`
 
@@ -370,7 +397,9 @@ Default value: `undef`
 
 Data type: `Optional[Array[String]]`
 
-
+Specifies the available MAC algorithms. When unset, a
+strong set of ciphers is automatically selected by this class, taking into
+account whether the server is in FIPS mode.
 
 Default value: `undef`
 
@@ -378,23 +407,20 @@ Default value: `undef`
 
 Data type: `Integer[1]`
 
-
+Specifies the maximum number of authentication attempts
+permitted per connection.
 
 Default value: 6
-
-##### `usepam`
-
-Data type: `Boolean`
-
-
-
-Default value: simplib::lookup('simp_options::pam', { 'default_value' => true })
 
 ##### `passwordauthentication`
 
 Data type: `Boolean`
 
+Enable password authentication on the sshd
+server. If set to undef, this setting will not be managed.
 
+* Note: This setting must be managed by default so that switching to and
+  from OATH does not lock you out of your system.
 
 Default value: `true`
 
@@ -402,7 +428,9 @@ Default value: `true`
 
 Data type: `Boolean`
 
-
+When password authentication is allowed,
+it specifies whether the server allows login to accounts with empty password
+strings.
 
 Default value: `false`
 
@@ -410,7 +438,7 @@ Default value: `false`
 
 Data type: `Ssh::PermitRootLogin`
 
-
+Specifies whether root can log in using SSH.
 
 Default value: `false`
 
@@ -418,7 +446,7 @@ Default value: `false`
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `false`
 
@@ -426,7 +454,7 @@ Default value: `false`
 
 Data type: `Simplib::Port`
 
-
+Specifies the port number SSHD listens on.
 
 Default value: 22
 
@@ -434,7 +462,8 @@ Default value: 22
 
 Data type: `Boolean`
 
-
+Specifies whether SSHD should print the date and
+time of the last user login when a user logs in interactively.
 
 Default value: `false`
 
@@ -442,7 +471,7 @@ Default value: `false`
 
 Data type: `Array[Integer[1,2]]`
 
-
+@see man page for sshd_config
 
 Default value: [2]
 
@@ -450,7 +479,11 @@ Default value: [2]
 
 Data type: `Optional[Boolean]`
 
-
+This sshd option has been completely removed in openssh 7.4 and
+will cause an error message to be logged, when present.  On systems
+using openssh 7.4 or later, only set this value if you need
+`RhostsRSAAuthentication` to be in the sshd configuration file to
+satisfy an outdated, STIG check.
 
 Default value: $ssh::server::params::rhostsrsaauthentication
 
@@ -458,7 +491,7 @@ Default value: $ssh::server::params::rhostsrsaauthentication
 
 Data type: `Boolean`
 
-
+@see man page for sshd_config
 
 Default value: `true`
 
@@ -466,7 +499,8 @@ Default value: `true`
 
 Data type: `String`
 
-
+Configures and external subsystem for file
+transfers.
 
 Default value: 'sftp /usr/libexec/openssh/sftp-server'
 
@@ -474,7 +508,8 @@ Default value: 'sftp /usr/libexec/openssh/sftp-server'
 
 Data type: `Ssh::Syslogfacility`
 
-
+Gives the facility code that is used when
+logging messages.
 
 Default value: 'AUTHPRIV'
 
@@ -482,15 +517,58 @@ Default value: 'AUTHPRIV'
 
 Data type: `Boolean`
 
-
+If true, allow sshd tcpwrapper.
 
 Default value: simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
+
+##### `usepam`
+
+Data type: `Boolean`
+
+Enables the Pluggable Authentication Module interface.
+
+Default value: simplib::lookup('simp_options::pam', { 'default_value' => true })
+
+##### `manage_pam_sshd`
+
+Data type: `Boolean`
+
+Flag indicating whether or not to mangae the
+pam stack for sshd. This is required for the oath option to work
+properly.
+
+Default value: $oath
+
+##### `oath`
+
+Data type: `Boolean`
+
+**EXPERIMENTAL FEATURE**
+Configures ssh to use pam_oath TOTP in the sshd pam stack.
+Also configures sshd_config to use required settings. Inherits from
+simp_options::oath, defaults to false if not found.
+
+* WARNING: If this setting is enabled then disabled and
+  passwordauthentication is unmanaged, this will be set to no
+  in sshd_config!
+
+Default value: simplib::lookup('simp_options::oath', { 'default_value' => false })
+
+##### `oath_window`
+
+Data type: `Integer[0]`
+
+Sets the TOTP window (Defined in RFC 6238 section 5.2)
+
+Default value: 1
 
 ##### `useprivilegeseparation`
 
 Data type: `Variant[Boolean,Enum['sandbox']]`
 
-
+Specifies whether sshd separates
+privileges by creating an unprivileged child process to deal with incoming
+network traffic.
 
 Default value: $ssh::server::params::useprivilegeseparation
 
@@ -498,7 +576,7 @@ Default value: $ssh::server::params::useprivilegeseparation
 
 Data type: `Boolean`
 
-
+Specifies whether X11 forwarding is permitted.
 
 Default value: `false`
 
@@ -506,7 +584,10 @@ Default value: `false`
 
 Data type: `String`
 
+* If pki = 'simp' or true, this is the directory from which certs will be
+  copied, via pki::copy.  Defaults to /etc/pki/simp/x509.
 
+* If pki = false, this variable has no effect.
 
 Default value: simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' })
 
@@ -514,7 +595,8 @@ Default value: simplib::lookup('simp_options::pki::source', { 'default_value' =>
 
 Data type: `Stdlib::Absolutepath`
 
-
+Path and name of the private SSL key file. This key file is used to generate
+the system SSH certificates for consistency.
 
 Default value: "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem"
 
@@ -522,7 +604,10 @@ Default value: "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem"
 
 Data type: `Boolean`
 
-
+If true, add the fallback ciphers
+from ssh::server::params to the cipher list. This is intended to provide
+compatibility with non-SIMP systems in a way that properly supports FIPS
+140-2.
 
 Default value: `true`
 
@@ -530,7 +615,9 @@ Default value: `true`
 
 Data type: `Array[String]`
 
-
+The set of ciphers that should be used should
+no other cipher be declared. This is used when
+$ssh::server::conf::enable_fallback_ciphers is enabled.
 
 Default value: $ssh::server::params::fallback_ciphers
 
@@ -538,7 +625,7 @@ Default value: $ssh::server::params::fallback_ciphers
 
 Data type: `Boolean`
 
-
+If set or FIPS is already enabled, adjust for FIPS mode.
 
 Default value: simplib::lookup('simp_options::fips', { 'default_value' => false })
 
@@ -546,7 +633,7 @@ Default value: simplib::lookup('simp_options::fips', { 'default_value' => false 
 
 Data type: `Boolean`
 
-
+If true, use the SIMP iptables class.
 
 Default value: simplib::lookup('simp_options::firewall', { 'default_value' => false })
 
@@ -554,7 +641,8 @@ Default value: simplib::lookup('simp_options::firewall', { 'default_value' => fa
 
 Data type: `Boolean`
 
-
+If true, include the haveged module to assist
+with entropy generation.
 
 Default value: simplib::lookup('simp_options::haveged', { 'default_value' => false })
 
@@ -562,39 +650,27 @@ Default value: simplib::lookup('simp_options::haveged', { 'default_value' => fal
 
 Data type: `Boolean`
 
-
+If true, enable LDAP support on the system. If
+authorizedkeyscommand is empty, this will set the authorizedkeyscommand to
+ssh-ldap-wrapper so that SSH public keys can be stored directly in LDAP.
 
 Default value: simplib::lookup('simp_options::ldap', { 'default_value' => false })
-
-##### `oath`
-
-Data type: `Boolean`
-
-
-
-Default value: simplib::lookup('simp_options::oath', { 'default_value' => false })
-
-##### `manage_pam_sshd`
-
-Data type: `Boolean`
-
-
-
-Default value: $oath
-
-##### `oath_window`
-
-Data type: `Integer[0]`
-
-
-
-Default value: 1
 
 ##### `pki`
 
 Data type: `Variant[Enum['simp'],Boolean]`
 
-
+* If 'simp', include SIMP's pki module and use pki::copy to manage
+  application certs in /etc/pki/simp_apps/sshd/x509
+* If true, do *not* include SIMP's pki module, but still use pki::copy
+  to manage certs in /etc/pki/simp_apps/sshd/x509
+* If false, do not include SIMP's pki module and do not use pki::copy
+  to manage certs.  You will need to appropriately assign a subset of:
+  * app_pki_dir
+  * app_pki_key
+  * app_pki_cert
+  * app_pki_ca
+  * app_pki_ca_dir
 
 Default value: simplib::lookup('simp_options::pki', { 'default_value' => false })
 
@@ -602,7 +678,7 @@ Default value: simplib::lookup('simp_options::pki', { 'default_value' => false }
 
 Data type: `Boolean`
 
-
+If true, use sssd.
 
 Default value: simplib::lookup('simp_options::sssd', { 'default_value' => false })
 
@@ -610,22 +686,18 @@ Default value: simplib::lookup('simp_options::sssd', { 'default_value' => false 
 
 Data type: `Simplib::Netlist`
 
-
+The networks to allow to connect to SSH.
 
 Default value: ['ALL']
 
 ### ssh::server::params
 
-Default parameters for the SSH Server
-
-KexAlgorithm configuration was not added until openssh 5.7
-Curve exchange was not fully supported until openssh 6.5
+* ``KexAlgorithm`` configuration was not added until openssh 5.7
+* ``Curve`` exchange was not fully supported until openssh 6.5
 
 ## Defined types
 
 ### ssh::client::host_config_entry
-
-Creates a host entry to ssh_config
 
 GSSAPI may be used.
 
@@ -1345,13 +1417,12 @@ The file that you wish to prune
 
 Type: Ruby 4.x API
 
-This function generates a random RSA SSH private and public key pair
-for a passed user.
+user.
 
-Keys are stored in 
+Keys are stored in
   "Puppet[:vardir]/simp/environments/<environment>/simp_autofiles/ssh_autokeys"
 
-Note: This function if marked as an InternalFunction because it 
+Note: This function if marked as an InternalFunction because it
 changes the state of the system by writing key files.
 
 #### `ssh::autokey(String $username, Optional[Hash] $options)`
@@ -1361,7 +1432,7 @@ The following options are supported:
 - 'return_private': whether to return the private key, Boolean, defaults to false
 NOTE: A minimum key strength of 1024 is enforced!
 
-Returns: `Any`
+Returns: `String` The public key of the user
 
 ##### `username`
 
@@ -1379,7 +1450,8 @@ Options hash
 
 NOTE: A minimum key strength of 1024 is enforced!
 
-Returns: `Any`
+Returns: `String` The public key of the user or the private key if
+return_private is specified.
 
 ##### `username`
 
@@ -1403,7 +1475,6 @@ whether to return the private key, defaults to false
 
 Type: Ruby 4.x API
 
-Translates true|false or 'true'|'false' to 'yes'|'no', respectively
 All other values are passed-through unchanged
 
 #### `ssh::config_bool_translate(String $config_item)`
@@ -1434,8 +1505,7 @@ Configuration item to be translated
 
 Type: Ruby 4.x API
 
-A method to sensibly format sort SSH 'host' entries which contain wildcards
-and question marks.
+wildcards and question marks.
 
 The output is intended for use with the simpcat_fragment type and is *not*
 meant for use as a host entry itself.
@@ -1459,8 +1529,7 @@ Output: 'foozzzz96_qu__.zzzz95_st__.bar'
 
 #### `ssh::format_host_entry_for_sorting(String $host_entry)`
 
-A method to sensibly format sort SSH 'host' entries which contain wildcards
-and question marks.
+wildcards and question marks.
 
 The output is intended for use with the simpcat_fragment type and is *not*
 meant for use as a host entry itself.
@@ -1494,9 +1563,7 @@ SSH host entry, which may contain wildcards
 
 Type: Ruby 4.x API
 
-Update the ssh_known_hosts files for all hosts, purging old files,
-removing duplicates, and creating catalog resources
-that are found
+removing duplicates, and creating catalog resources that are found
 
  Note: This function if marked as an InternalFunction because it
  changes the state of the system by adding/removing files and
@@ -1504,15 +1571,13 @@ that are found
 
 #### `ssh::global_known_hosts(Optional[Integer] $expire_days)`
 
-Update the ssh_known_hosts files for all hosts, purging old files,
-removing duplicates, and creating catalog resources
-that are found
+removing duplicates, and creating catalog resources that are found
 
  Note: This function if marked as an InternalFunction because it
  changes the state of the system by adding/removing files and
  adding catalog resources.
 
-Returns: `Any`
+Returns: `None`
 
 ##### `expire_days`
 
@@ -1547,8 +1612,6 @@ The ssh key, can be pasted from ~/.ssh/id_rsa.pub or similar
 
 Type: Ruby 3.x API
 
-This function generates a random RSA SSH private and public key pair for a passed user.
-
 Keys are stored in "Puppet[:vardir]/simp/environments/<environment>/simp_autofiles/ssh_autokeys"
 
 Arguments: username, [option_hash|integer], [return_private]
@@ -1565,8 +1628,6 @@ Arguments: username, [option_hash|integer], [return_private]
 
 #### `ssh_autokey()`
 
-This function generates a random RSA SSH private and public key pair for a passed user.
-
 Keys are stored in "Puppet[:vardir]/simp/environments/<environment>/simp_autofiles/ssh_autokeys"
 
 Arguments: username, [option_hash|integer], [return_private]
@@ -1581,17 +1642,27 @@ Arguments: username, [option_hash|integer], [return_private]
 
   NOTE: A minimum key strength of 1024 will be enforc
 
-Returns: `Any`
+Returns: `String` The public cert of the passed user or the private key if requested.
 
 ### ssh_global_known_hosts
 
 Type: Ruby 3.x API
 
-DEPRECATED: This function updates the ssh_known_hosts file for all hosts and updates any new ones that are found.\nThis function takes one argument, expire time which is specified in days. Default expire time is 7 days. Set to '0' to never purge.
+This function updates the ssh_known_hosts file for all hosts and updates
+any new ones that are found.
+
+This function takes one argument, expire time which is specified in days.
+
+Default expire time is 7 days. Set to '0' to never p
 
 #### `ssh_global_known_hosts()`
 
-DEPRECATED: This function updates the ssh_known_hosts file for all hosts and updates any new ones that are found.\nThis function takes one argument, expire time which is specified in days. Default expire time is 7 days. Set to '0' to never purge.
+This function updates the ssh_known_hosts file for all hosts and updates
+any new ones that are found.
 
-Returns: `Any`
+This function takes one argument, expire time which is specified in days.
+
+Default expire time is 7 days. Set to '0' to never p
+
+Returns: `None`
 

--- a/lib/puppet/functions/ssh/autokey.rb
+++ b/lib/puppet/functions/ssh/autokey.rb
@@ -1,10 +1,10 @@
-# This function generates a random RSA SSH private and public key pair
-# for a passed user.
+# @summary Generates a random RSA SSH private and public key pair for a passed
+# user.
 #
-# Keys are stored in 
+# Keys are stored in
 #   "Puppet[:vardir]/simp/environments/<environment>/simp_autofiles/ssh_autokeys"
 #
-# Note: This function if marked as an InternalFunction because it 
+# Note: This function if marked as an InternalFunction because it
 # changes the state of the system by writing key files.
 #
 Puppet::Functions.create_function(:'ssh::autokey', Puppet::Functions::InternalFunction) do
@@ -14,6 +14,8 @@ Puppet::Functions.create_function(:'ssh::autokey', Puppet::Functions::InternalFu
   # - 'key_strength': key length, Integer, defaults to 2048
   # - 'return_private': whether to return the private key, Boolean, defaults to false
   # NOTE: A minimum key strength of 1024 is enforced!
+  #
+  # @return [String] The public key of the user
   dispatch :autokey_with_options_hash do
     required_param 'String', :username
     optional_param 'Hash', :options
@@ -23,6 +25,9 @@ Puppet::Functions.create_function(:'ssh::autokey', Puppet::Functions::InternalFu
   # @param key_strength key length, defaults to 2048
   # @param return_private whether to return the private key, defaults to false
   # NOTE: A minimum key strength of 1024 is enforced!
+  #
+  # @return [String] The public key of the user or the private key if
+  #   return_private is specified.
   dispatch :autokey do
     required_param 'String', :username
     optional_param 'Integer', :key_strength

--- a/lib/puppet/functions/ssh/config_bool_translate.rb
+++ b/lib/puppet/functions/ssh/config_bool_translate.rb
@@ -1,4 +1,5 @@
-# Translates true|false or 'true'|'false' to 'yes'|'no', respectively
+# @summary Translates true|false or 'true'|'false' to 'yes'|'no', respectively
+#
 # All other values are passed-through unchanged
 Puppet::Functions.create_function(:'ssh::config_bool_translate') do
 

--- a/lib/puppet/functions/ssh/format_host_entry_for_sorting.rb
+++ b/lib/puppet/functions/ssh/format_host_entry_for_sorting.rb
@@ -1,5 +1,5 @@
-# A method to sensibly format sort SSH 'host' entries which contain wildcards
-# and question marks.
+# @summary A method to sensibly format sort SSH 'host' entries which contain
+# wildcards and question marks.
 #
 # The output is intended for use with the simpcat_fragment type and is *not*
 # meant for use as a host entry itself.

--- a/lib/puppet/functions/ssh/global_known_hosts.rb
+++ b/lib/puppet/functions/ssh/global_known_hosts.rb
@@ -1,6 +1,5 @@
-# Update the ssh_known_hosts files for all hosts, purging old files,
-# removing duplicates, and creating catalog resources
-# that are found
+# @summary Update the ssh_known_hosts files for all hosts, purging old files,
+# removing duplicates, and creating catalog resources that are found
 #
 #  Note: This function if marked as an InternalFunction because it
 #  changes the state of the system by adding/removing files and
@@ -10,6 +9,8 @@ Puppet::Functions.create_function(:'ssh::global_known_hosts', Puppet::Functions:
 
   # @param expire_days expire time in days; defaults to 7; value of 0
   #   means never purge
+  #
+  # @return [None]
   dispatch :global_known_hosts do
     optional_param 'Integer', :expire_days
   end
@@ -38,7 +39,7 @@ Puppet::Functions.create_function(:'ssh::global_known_hosts', Puppet::Functions:
       end
     end
   end
- 
+
   def write_this_host_key_file(basedir)
     #FIXME accessing facts per the documentation doesn't work in unit tests
     # fqdn = closure_scope['facts']['networking']['fqdn']

--- a/lib/puppet/parser/functions/ssh_autokey.rb
+++ b/lib/puppet/parser/functions/ssh_autokey.rb
@@ -1,8 +1,10 @@
 module Puppet::Parser::Functions
   newfunction(:ssh_autokey, :type => :rvalue, :doc => <<-EOM) do |args|
-    This function generates a random RSA SSH private and public key pair for a passed user.
+    @summary Generates a random RSA SSH private and public key pair for a passed user.
 
     Keys are stored in "Puppet[:vardir]/simp/environments/<environment>/simp_autofiles/ssh_autokeys"
+
+    @return [String] The public cert of the passed user or the private key if requested.
 
     Arguments: username, [option_hash|integer], [return_private]
       * If an integer is the second argument, it will be used as the key strength

--- a/lib/puppet/parser/functions/ssh_global_known_hosts.rb
+++ b/lib/puppet/parser/functions/ssh_global_known_hosts.rb
@@ -1,6 +1,19 @@
+# Deprecation function notice
+#
 module Puppet::Parser::Functions
-  newfunction(:ssh_global_known_hosts, :doc => "DEPRECATED: This function updates the ssh_known_hosts file for all hosts and updates any new ones that are found.\nThis function takes one argument, expire time which is specified in days. Default expire time is 7 days. Set to '0' to never purge.") do |args|
+  newfunction(:ssh_global_known_hosts, :doc => <<-EOS) do |args|
+    @summary **DEPRECATED**
 
-      raise("ssh_global_known_hosts does not work.  Use ssh::global_known_hosts, instead, and include simp/ssh module in the module's metadata.json") 
+    This function updates the ssh_known_hosts file for all hosts and updates
+    any new ones that are found.
+
+    @return [None]
+
+    This function takes one argument, expire time which is specified in days.
+
+    Default expire time is 7 days. Set to '0' to never purge.
+  EOS
+
+      raise("ssh_global_known_hosts does not work.  Use ssh::global_known_hosts, instead, and include simp/ssh module in the module's metadata.json")
   end
 end

--- a/lib/puppet/provider/sshkey_prune/prune.rb
+++ b/lib/puppet/provider/sshkey_prune/prune.rb
@@ -1,4 +1,5 @@
 Puppet::Type.type(:sshkey_prune).provide(:prune) do
+  desc 'Update and prune gathered Host SSH keys'
 
   def insync?(is)
     sys_diff = (@system_hosts.keys - is)

--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -1,6 +1,6 @@
-# Add `ssh_authorized_keys` via hiera in a loop
+# @summary Add `ssh_authorized_keys` via hiera in a loop
 #
-# It was designed so you can just paste the output of the ssh pubkey into
+# This class was designed so you can just paste the output of the ssh pubkey into
 # hiera and it will work. See the example below for details.
 #
 # > **WARNING**

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -17,6 +17,7 @@ class ssh::client (
   Boolean $fips              = simplib::lookup('simp_options::fips', { 'default_value' => false }),
   String  $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
+  simplib::assert_metadata( $module_name )
 
   if $add_default_entry {
     ssh::client::host_config_entry { '*': }
@@ -40,6 +41,8 @@ class ssh::client (
   }
 
   if $haveged {
-    include '::haveged'
+    simplib::assert_optional_dependency($module_name, 'simp/haveged')
+
+    include 'haveged'
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,4 +1,4 @@
-# Sets up a ssh client and creates /etc/ssh/ssh_config.
+# @summary Sets up a ssh client and creates /etc/ssh/ssh_config.
 #
 # @param add_default_entry Set this if you wish to automatically
 #   have the '*' Host entry set up with some sane defaults.

--- a/manifests/client/host_config_entry.pp
+++ b/manifests/client/host_config_entry.pp
@@ -333,18 +333,18 @@ define ssh::client::host_config_entry (
   Boolean                                               $visualhostkey                    = false,
   Stdlib::Absolutepath                                  $xauthlocation                    = '/usr/bin/xauth'
 ) {
-  include '::ssh::client::params'
-  include '::ssh::client'
+  include 'ssh::client::params'
+  include 'ssh::client'
 
   if $macs and !empty($macs) {
     $_macs = $macs
   }
   else {
-    if $::ssh::client::fips or $facts['fips_enabled'] {
-      $_macs = $::ssh::client::params::fips_macs
+    if $ssh::client::fips or $facts['fips_enabled'] {
+      $_macs = $ssh::client::params::fips_macs
     }
     else {
-      $_macs = $::ssh::client::params::macs
+      $_macs = $ssh::client::params::macs
     }
   }
 
@@ -352,15 +352,15 @@ define ssh::client::host_config_entry (
     $_ciphers = $ciphers
   }
   else {
-    if $::ssh::client::fips or $facts['fips_enabled'] {
-      $_ciphers = $::ssh::client::params::fips_ciphers
+    if $ssh::client::fips or $facts['fips_enabled'] {
+      $_ciphers = $ssh::client::params::fips_ciphers
     }
     else {
-      $_ciphers = $::ssh::client::params::ciphers
+      $_ciphers = $ssh::client::params::ciphers
     }
   }
 
-  if $::ssh::client::fips or $facts['fips_enabled'] {
+  if $ssh::client::fips or $facts['fips_enabled'] {
     $_protocol = 2
     $_cipher = undef
   }
@@ -374,7 +374,7 @@ define ssh::client::host_config_entry (
   }
 
   # If the host is configured to use IPA, enable this setting
-  if $gssapiauthentication or $::ssh::client::params::gssapiauthentication {
+  if $gssapiauthentication or $ssh::client::params::gssapiauthentication {
     $_gssapiauthentication = true
   }
   else {

--- a/manifests/client/host_config_entry.pp
+++ b/manifests/client/host_config_entry.pp
@@ -1,4 +1,4 @@
-# Creates a host entry to ssh_config
+# @summary Creates a host entry to ssh_config
 #
 # @example Adding default entry
 #

--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -1,4 +1,4 @@
-# Default parameters for the SSH client
+# @summary Default parameters for the SSH client
 #
 # @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,10 @@ class ssh (
   Boolean $enable_server = true
 ){
 
-  if $enable_client { include '::ssh::client' }
-  if $enable_server { include '::ssh::server' }
+  simplib::assert_metadata( $module_name )
+
+  if $enable_client { include 'ssh::client' }
+  if $enable_server { include 'ssh::server' }
 
   file { '/etc/ssh':
     owner => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Sets up files for ssh.
+# @summary Sets up files for ssh.
 #
 # @param enable_client  If true, set up the SSH client configuration files.
 #

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,9 +10,10 @@ class ssh::server (
   String $server_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String $ldap_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
+  simplib::assert_metadata( $module_name )
 
-  include '::ssh'
-  include '::ssh::server::conf'
+  include 'ssh'
+  include 'ssh::server::conf'
 
   file { '/etc/ssh/moduli':
     owner => 'root',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,4 @@
-# Sets up a ssh server and starts sshd.
+# @summary Sets up a ssh server and starts sshd.
 #
 # @param server_ensure The ensure status of the openssh-server package
 #

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -131,19 +131,19 @@
 #
 # @param usepam Enables the Pluggable Authentication Module interface.
 #
-# @param manage_pam_sshd Flag indicating whether or not to mangae the 
-#   pam stack for sshd. This is required for the oath option to work 
+# @param manage_pam_sshd Flag indicating whether or not to mangae the
+#   pam stack for sshd. This is required for the oath option to work
 #   properly.
 #
 # @param oath  Configures ssh to use pam_oath TOTP in the sshd pam stack.
 #   Also configures sshd_config to use required settings. Inherits from
-#   simp_options::oath, defaults to false if not found. 
-#   WARNING: If this setting is enabled then disabled and 
+#   simp_options::oath, defaults to false if not found.
+#   WARNING: If this setting is enabled then disabled and
 #            passwordauthentication is unmanaged, this will be set to no
-#            in sshd_config! 
-#   WARNING: pupmod-simp-oath is a dependency of this option. If this is                                                                                                                                          
-#            set to true without the oath module, you will be unable to                                                                                                                                           
-#            log in locally!  
+#            in sshd_config!
+#   WARNING: pupmod-simp-oath is a dependency of this option. If this is
+#            set to true without the oath module, you will be unable to
+#            log in locally!
 #
 # @param oath_window  Sets the TOTP window (Defined in RFC 6238 section 5.2)
 #

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -172,7 +172,7 @@
 #
 # @param fallback_ciphers  The set of ciphers that should be used should
 #   no other cipher be declared. This is used when
-#   $::ssh::server::conf::enable_fallback_ciphers is enabled.
+#   $ssh::server::conf::enable_fallback_ciphers is enabled.
 #
 # @param fips If set or FIPS is already enabled, adjust for FIPS mode.
 #
@@ -205,7 +205,7 @@
 
 class ssh::server::conf (
 #### SSH Parameters ####
-  Array[String]                    $acceptenv                       = $::ssh::server::params::acceptenv,
+  Array[String]                    $acceptenv                       = $ssh::server::params::acceptenv,
   Optional[Array[String]]          $allowgroups                     = undef,
   Optional[Array[String]]          $allowusers                      = undef,
   String                           $authorizedkeysfile              = '/etc/ssh/local_keys/%u',
@@ -219,7 +219,7 @@ class ssh::server::conf (
   Variant[Boolean,Enum['delayed']] $compression                     = 'delayed',
   Optional[Array[String]]          $denygroups                      = undef,
   Optional[Array[String]]          $denyusers                       = undef,
-  Boolean                          $gssapiauthentication            = $::ssh::server::params::gssapiauthentication,
+  Boolean                          $gssapiauthentication            = $ssh::server::params::gssapiauthentication,
   Boolean                          $hostbasedauthentication         = false,
   Boolean                          $ignorerhosts                    = true,
   Boolean                          $ignoreuserknownhosts            = true,
@@ -231,54 +231,35 @@ class ssh::server::conf (
   Optional[Array[String]]          $macs                            = undef,
   Integer[1]                       $maxauthtries                    = 6,
   Boolean                          $usepam                          = simplib::lookup('simp_options::pam', { 'default_value' => true }),
-  Optional[Boolean]                $passwordauthentication          = true,
+  Boolean                          $passwordauthentication          = true,
   Boolean                          $permitemptypasswords            = false,
   Ssh::PermitRootLogin             $permitrootlogin                 = false,
   Boolean                          $permituserenvironment           = false,
   Simplib::Port                    $port                            = 22,
   Boolean                          $printlastlog                    = false,
   Array[Integer[1,2]]              $protocol                        = [2],
-  Optional[Boolean]                $rhostsrsaauthentication         = $::ssh::server::params::rhostsrsaauthentication,
+  Optional[Boolean]                $rhostsrsaauthentication         = $ssh::server::params::rhostsrsaauthentication,
   Boolean                          $strictmodes                     = true,
   String                           $subsystem                       = 'sftp /usr/libexec/openssh/sftp-server',
   Ssh::Syslogfacility              $syslogfacility                  = 'AUTHPRIV',
   Boolean                          $tcpwrappers                     = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }),
-  Variant[Boolean,Enum['sandbox']] $useprivilegeseparation          = $::ssh::server::params::useprivilegeseparation,
+  Variant[Boolean,Enum['sandbox']] $useprivilegeseparation          = $ssh::server::params::useprivilegeseparation,
   Boolean                          $x11forwarding                   = false,
 #### SIMP parameters ####
   String                           $app_pki_external_source         = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath             $app_pki_key                     = "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem",
   Boolean                          $enable_fallback_ciphers         = true,
-  Array[String]                    $fallback_ciphers                = $::ssh::server::params::fallback_ciphers,
+  Array[String]                    $fallback_ciphers                = $ssh::server::params::fallback_ciphers,
   Boolean                          $fips                            = simplib::lookup('simp_options::fips', { 'default_value' => false }),
   Boolean                          $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Boolean                          $haveged                         = simplib::lookup('simp_options::haveged', { 'default_value' => false }),
   Boolean                          $ldap                            = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
+  Boolean                          $oath                            = simplib::lookup('simp_options::oath', { 'default_value' => false }),
+  Boolean                          $manage_pam_sshd                 = $oath,
+  Integer[0]                       $oath_window                     = 1,
   Variant[Enum['simp'],Boolean]    $pki                             = simplib::lookup('simp_options::pki', { 'default_value' => false }),
   Boolean                          $sssd                            = simplib::lookup('simp_options::sssd', { 'default_value' => false }),
-  Simplib::Netlist                 $trusted_nets                    = ['ALL'],
-  Boolean                          $pam                             = simplib::lookup('simp_options::pam', { 'default_value'         => true }),
-  Boolean                          $display_account_lock            = simplib::lookup('pam::display_account_lock', { 'default_value' => false }),
-  Integer[0]                       $deny                            = simplib::lookup('pam::deny', { 'default_value'                 => 5 }),
-  Integer[0]                       $unlock_time                     = simplib::lookup('pam::unlock_time', { 'default_value'          => 900 }),
-  Integer[0]                       $fail_interval                   = simplib::lookup('pam::fail_interval', { 'default_value'        => 900 }),
-  Boolean                          $even_deny_root                  = simplib::lookup('pam::even_deny_root', { 'default_value'       => true }),
-  Integer[0]                       $root_unlock_time                = simplib::lookup('pam::root_unlock_time', { 'default_value'     => 60 }),
-  Boolean                          $manage_pam_sshd                 = true,
-  Boolean                          $oath                            = simplib::lookup('simp_options::oath', { 'default_value'        => false }),
-  Integer[0]                       $oath_window                     = 1,
-  Variant[Boolean,Enum['sandbox']] $useprivilegeseparation          = $::ssh::server::params::useprivilegeseparation,
-  Boolean                          $x11forwarding                   = false,
-  Simplib::Netlist                 $trusted_nets                    = ['ALL'],
-  Boolean                          $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value'    => false }),
-  Boolean                          $ldap                            = simplib::lookup('simp_options::ldap', { 'default_value'        => false }),
-  Boolean                          $sssd                            = simplib::lookup('simp_options::sssd', { 'default_value'        => false }),
-  Boolean                          $haveged                         = simplib::lookup('simp_options::haveged', { 'default_value'     => false }),
-  Boolean                          $tcpwrappers                     = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }),
-  Boolean                          $fips                            = simplib::lookup('simp_options::fips', { 'default_value'        => false }),
-  Variant[Enum['simp'],Boolean]    $pki                             = simplib::lookup('simp_options::pki', { 'default_value'         => false }),
-  String                           $app_pki_external_source         = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
-  Stdlib::Absolutepath             $app_pki_key                     = "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem"
+  Simplib::Netlist                 $trusted_nets                    = ['ALL']
 ) inherits ::ssh::server::params {
   assert_private()
 
@@ -291,7 +272,9 @@ class ssh::server::conf (
   }
 
   if $haveged {
-    include '::haveged'
+    simplib::assert_optional_dependency($module_name, 'simp/haveged')
+
+    include 'haveged'
   }
 
   if $authorizedkeyscommand {
@@ -303,6 +286,8 @@ class ssh::server::conf (
   }
 
   if $pki {
+    simplib::assert_optional_dependency($module_name, 'simp/pki')
+
     pki::copy { 'sshd':
       source => $app_pki_external_source,
       pki    => $pki,
@@ -321,16 +306,15 @@ class ssh::server::conf (
     $_use_ldap = $ldap
   }
 
-
   if $macs and !empty($macs) {
     $_macs = $macs
   }
   else {
     if $fips or $facts['fips_enabled'] {
-      $_macs = $::ssh::server::params::fips_macs
+      $_macs = $ssh::server::params::fips_macs
     }
     else {
-      $_macs = $::ssh::server::params::macs
+      $_macs = $ssh::server::params::macs
     }
   }
 
@@ -341,10 +325,10 @@ class ssh::server::conf (
   }
   else {
     if $fips or $facts['fips_enabled'] {
-      $_main_ciphers = $::ssh::server::params::fips_ciphers
+      $_main_ciphers = $ssh::server::params::fips_ciphers
     }
     else {
-      $_main_ciphers = $::ssh::server::params::ciphers
+      $_main_ciphers = $ssh::server::params::ciphers
     }
   }
 
@@ -360,33 +344,30 @@ class ssh::server::conf (
   }
   else {
     if $fips or $facts['fips_enabled'] {
-      $_kex_algorithms = $::ssh::server::params::fips_kex_algorithms
+      $_kex_algorithms = $ssh::server::params::fips_kex_algorithms
     }
     else {
-      $_kex_algorithms = $::ssh::server::params::kex_algorithms
+      $_kex_algorithms = $ssh::server::params::kex_algorithms
     }
   }
 
-  if $oath and !$pam {
-    fail('$pam must be set if $oath is set')
+  if $oath {
+    $_usepam = true
+  }
+  else {
+    $_usepam = $usepam
   }
 
-  if $pam {
-    simplib::assert_optional_dependency($module_name, 'simp/pam')
+  if $_usepam {
     if $oath {
-      if $manage_pam_sshd {
-        simplib::assert_optional_dependency($module_name, 'simp/oath')
-        $_challengeresponseauthentication = true
-        $_passwordauthentication = false
-      }
-      else {
-        fail('manage_pam_sshd must be true for oath to work')
-      }
+      simplib::assert_optional_dependency($module_name, 'simp/oath')
+
+      include 'oath'
+
+      $_challengeresponseauthentication = true
+      $_passwordauthentication = false
     }
-    else {
-      $_passwordauthentication = $passwordauthentication
-      $_challengeresponseauthentication = $challengeresponseauthentication
-    }
+
     if $manage_pam_sshd {
       if $facts['os']['release']['major'] == '6'{
         file { '/etc/pam.d/sshd':
@@ -401,7 +382,7 @@ class ssh::server::conf (
         }
       }
       else {
-        fail('Unsupported RedHat major release version!')
+        fail("Unsupported EL version ${facts['os']['release']['major']}!")
       }
     }
   }
@@ -410,7 +391,7 @@ class ssh::server::conf (
     owner  => 'root',
     group  => 'root',
     mode   => '0600',
-    notify => Service['sshd'],
+    notify => Service['sshd']
   }
 
   sshd_config { 'AcceptEnv'                       : value => $acceptenv }
@@ -423,9 +404,12 @@ class ssh::server::conf (
     }
   }
   elsif $sssd {
-    include '::sssd::install'
+    simplib::assert_optional_dependency($module_name, 'simp/sssd')
+
+    include 'sssd::install'
 
     sshd_config { 'AuthorizedKeysCommand'         : value => '/usr/bin/sss_ssh_authorizedkeys' }
+
     if $rhel_greater_than_6 {
       sshd_config { 'AuthorizedKeysCommandUser'   : value => $authorizedkeyscommanduser }
     }
@@ -438,7 +422,7 @@ class ssh::server::conf (
   }
   sshd_config { 'AuthorizedKeysFile'              : value => $authorizedkeysfile }
   sshd_config { 'Banner'                          : value => $banner }
-  sshd_config { 'ChallengeResponseAuthentication' : value => ssh::config_bool_translate($_challengeresponseauthentication) }
+  sshd_config { 'ChallengeResponseAuthentication' : value => ssh::config_bool_translate(defined('$_challengeresponseauthentication') ? { true => $_challengeresponseauthentication, default => $challengeresponseauthentication } ) }
   sshd_config { 'Ciphers'                         : value => $_ciphers }
   sshd_config { 'ClientAliveInterval'             : value => String($clientaliveinterval) }
   sshd_config { 'ClientAliveCountMax'             : value => String($clientalivecountmax) }
@@ -459,9 +443,7 @@ class ssh::server::conf (
   sshd_config { 'LogLevel'                        : value => $ssh_loglevel }
   sshd_config { 'MACs'                            : value => $_macs }
   sshd_config { 'MaxAuthTries'                    : value => $maxauthtries }
-  if $passwordauthentication != undef {
-    sshd_config { 'PasswordAuthentication'        : value => ssh::config_bool_translate($passwordauthentication) }
-  }
+  sshd_config { 'PasswordAuthentication'          : value => ssh::config_bool_translate(defined('$_passwordauthentication') ? { true => $_passwordauthentication, default => $passwordauthentication} ) }
   sshd_config { 'PermitEmptyPasswords'            : value => ssh::config_bool_translate($permitemptypasswords) }
   sshd_config { 'PermitRootLogin'                 : value => ssh::config_bool_translate($permitrootlogin) }
   sshd_config { 'PermitUserEnvironment'           : value => ssh::config_bool_translate($permituserenvironment) }
@@ -473,43 +455,12 @@ class ssh::server::conf (
   }
   sshd_config { 'StrictModes'                     : value => ssh::config_bool_translate($strictmodes) }
   sshd_config { 'SyslogFacility'                  : value => $syslogfacility}
-  sshd_config { 'UsePAM'                          : value => ssh::config_bool_translate($usepam) }
+  sshd_config { 'UsePAM'                          : value => ssh::config_bool_translate(defined('$_usepam') ? { true => $_usepam, default => $usepam } ) }
   sshd_config { 'UsePrivilegeSeparation'          : value => ssh::config_bool_translate($useprivilegeseparation) }
   sshd_config { 'X11Forwarding'                   : value => ssh::config_bool_translate($x11forwarding) }
 
-  if $rhostsrsaauthentication != undef {
-    sshd_config { 'RhostsRSAAuthentication' : value => ssh::config_bool_translate($rhostsrsaauthentication) }
-  }
-
-  if $_passwordauthentication != undef {
-    sshd_config { 'PasswordAuthentication' : value => ssh::config_bool_translate($_passwordauthentication) }
-  }
-
-  # Kex should be empty openssl < 5.7, they are not supported.
-  if !empty($_kex_algorithms) { sshd_config { 'KexAlgorithms': value => $_kex_algorithms } }
-
-  if $authorizedkeyscommand {
-    sshd_config { 'AuthorizedKeysCommand': value => $authorizedkeyscommand }
-    if $rhel_greater_than_6 {
-      sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
-    }
-  }
-  elsif $sssd {
-    include '::sssd::install'
-
-    sshd_config { 'AuthorizedKeysCommand': value => '/usr/bin/sss_ssh_authorizedkeys' }
-    if $rhel_greater_than_6 {
-      sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
-    }
-  }
-  elsif $_use_ldap {
-    sshd_config { 'AuthorizedKeysCommand': value => '/usr/libexec/openssh/ssh-ldap-wrapper' }
-    if $rhel_greater_than_6 {
-      sshd_config { 'AuthorizedKeysCommandUser': value => $authorizedkeyscommanduser }
-    }
-  }
-
   $subsystem_array = split($subsystem, ' +')
+
   sshd_config_subsystem { $subsystem_array[0]: command => join($subsystem_array[1,-1], ' ') }
 
   file { '/etc/ssh/local_keys':
@@ -521,7 +472,9 @@ class ssh::server::conf (
   }
 
   if $firewall {
-    include '::iptables'
+    simplib::assert_optional_dependency($module_name, 'simp/iptables')
+
+    include 'iptables'
 
     iptables::listen::tcp_stateful { 'allow_sshd':
       order        => 8,
@@ -531,7 +484,10 @@ class ssh::server::conf (
   }
 
   if $tcpwrappers {
-    include '::tcpwrappers'
+    simplib::assert_optional_dependency($module_name, 'simp/tcpwrappers')
+
+    include 'tcpwrappers'
+
     tcpwrappers::allow { 'sshd':
       pattern => simplib::nets2ddq($trusted_nets),
       order   => 1

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -1,7 +1,7 @@
-# Sets up sshd_config and adds an iptables rule if iptables is being used.
+# @summary Sets up sshd_config and adds an iptables rule if iptables is being used.
 #
-# sshd configuration variables can be set using Augeas outside of this class
-# with no adverse effects.
+# ``sshd`` configuration variables can be set using Augeas outside of this
+# class with no adverse effects.
 #
 #### SSH Parameters ####
 #
@@ -84,7 +84,7 @@
 #   strong set of ciphers is automatically selected by this class, taking into
 #   account whether the server is in FIPS mode.
 #
-# @pram maxauthtries  Specifies the maximum number of authentication attempts
+# @param maxauthtries  Specifies the maximum number of authentication attempts
 #   permitted per connection.
 #
 # @param passwordauthentication Enable password authentication on the sshd
@@ -202,7 +202,6 @@
 #
 # @param trusted_nets  The networks to allow to connect to SSH.
 #
-
 class ssh::server::conf (
 #### SSH Parameters ####
   Array[String]                    $acceptenv                       = $ssh::server::params::acceptenv,

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -135,15 +135,15 @@
 #   pam stack for sshd. This is required for the oath option to work
 #   properly.
 #
-# @param oath  Configures ssh to use pam_oath TOTP in the sshd pam stack.
+# @param oath
+#   **EXPERIMENTAL FEATURE**
+#   Configures ssh to use pam_oath TOTP in the sshd pam stack.
 #   Also configures sshd_config to use required settings. Inherits from
 #   simp_options::oath, defaults to false if not found.
-#   WARNING: If this setting is enabled then disabled and
-#            passwordauthentication is unmanaged, this will be set to no
-#            in sshd_config!
-#   WARNING: pupmod-simp-oath is a dependency of this option. If this is
-#            set to true without the oath module, you will be unable to
-#            log in locally!
+#
+#   * WARNING: If this setting is enabled then disabled and
+#     passwordauthentication is unmanaged, this will be set to no
+#     in sshd_config!
 #
 # @param oath_window  Sets the TOTP window (Defined in RFC 6238 section 5.2)
 #

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -1,7 +1,7 @@
-# Default parameters for the SSH Server
+# @summary Default parameters for the SSH Server
 #
-# KexAlgorithm configuration was not added until openssh 5.7
-# Curve exchange was not fully supported until openssh 6.5
+# * ``KexAlgorithm`` configuration was not added until openssh 5.7
+# * ``Curve`` exchange was not fully supported until openssh 6.5
 #
 # @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #

--- a/metadata.json
+++ b/metadata.json
@@ -59,6 +59,18 @@
       "version_requirement": ">= 3.9.0 < 4.0.0"
     }
   ],
+  "simp": {
+    "optional_dependencies": [
+      {
+        "name": "simp/oath",
+        "version_requirement": ">= 0.1.0 < 1.0.0"
+      },
+      {
+        "name": "simp/pam",
+        "version_requirement": ">= 6.3.0 < 7.0.0"
+      }
+    ]
+  },
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",

--- a/metadata.json
+++ b/metadata.json
@@ -15,10 +15,6 @@
   ],
   "dependencies": [
     {
-      "name": "simp/auditd",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
-    },
-    {
       "name": "herculesteam/augeasproviders_core",
       "version_requirement": ">= 2.1.1 < 3.0.0"
     },
@@ -31,28 +27,8 @@
       "version_requirement": ">= 2.5.0 < 4.0.0"
     },
     {
-      "name": "simp/haveged",
-      "version_requirement": ">= 0.3.2 < 1.0.0"
-    },
-    {
-      "name": "simp/pki",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/stunnel",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/tcpwrappers",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 6.0.0"
-    },
-    {
-      "name": "simp/iptables",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "simp/simplib",
@@ -62,12 +38,32 @@
   "simp": {
     "optional_dependencies": [
       {
+        "name": "simp/haveged",
+        "version_requirement": ">= 0.3.2 < 1.0.0"
+      },
+      {
+        "name": "simp/iptables",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      },
+      {
         "name": "simp/oath",
         "version_requirement": ">= 0.1.0 < 1.0.0"
       },
       {
+        "name": "simp/pki",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      },
+      {
+        "name": "simp/tcpwrappers",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      },
+      {
         "name": "simp/pam",
         "version_requirement": ">= 6.3.0 < 7.0.0"
+      },
+      {
+        "name": "simp/sssd",
+        "version_requirement": ">= 6.1.6 < 7.0.0"
       }
     ]
   },

--- a/spec/acceptance/suites/default/10_pam_oath_spec.rb
+++ b/spec/acceptance/suites/default/10_pam_oath_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper_acceptance'
+require 'json'
+
+test_name 'ssh check oath'
+
+describe 'ssh check oath' do
+  let(:client_hieradata) { 'simp_options::oath => false' }
+
+  let(:server_hieradata) do
+    {
+      'simp_options::trusted_nets'            => ['ALL'],
+      'simp_options::oath'                    => true,
+      'simp_options::pam'                     => true,
+      'ssh::server::conf::banner'             => '/dev/null',
+      'ssh::server::conf::permitrootlogin'    => true,
+      'ssh::server::conf::authorizedkeysfile' => '.ssh/authorized_keys',
+      'pam::access::users'                    => JSON.parse(%Q({ "defaults": { "origins": [ "ALL" ], "permission": "+" }, "vagrant": null, "root": null, "testuser": null, "tst0_usr": null })),
+      'oath::oath_users'                      => JSON.parse(%Q({"tst0_usr": {"token_type": "HOTP/T30/6", "pin": "-", "secret_key": "000001"}}))
+    }
+  end
+
+  #
+  # NOTE: by default, include 'ssh' will automatically include the ssh_server
+  let(:client_manifest) do
+    <<-CLIENT_CONFIG
+         include 'ssh::client'
+         include 'oath'
+    CLIENT_CONFIG
+  end
+
+  let(:server_manifest) do
+    <<-SERVER_CONFIG
+         include 'ssh::server'
+         include 'oath'
+         include 'pam'
+    SERVER_CONFIG
+  end
+  let(:password) { 'suP3rF00B@rB@11bx23' }
+
+  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+
+  hosts_as('server').each do |_server|
+    os = _server.hostname.split('-').first
+    context "on #{os}:" do
+      let(:server) { _server }
+
+      let(:client) do
+        os = server.hostname.split('-').first
+        hosts_as('client').select { |x| x.hostname =~ %r{^#{os}-.+} }.first
+      end
+
+      context 'with default parameters' do
+        it 'configures server with no errors' do
+          install_package(client, 'epel-release')
+          install_package(client, 'expect')
+          set_hieradata_on(client, client_hieradata)
+          apply_manifest_on(client, client_manifest, expect_changes: true)
+          set_hieradata_on(server, server_hieradata)
+          apply_manifest_on(server, server_manifest, expect_changes: true)
+        end
+
+        it "should configure #{os}-server idempotently" do
+          set_hieradata_on(server, server_hieradata)
+          apply_manifest_on(server, server_manifest, catch_changes: true)
+        end
+
+        it "should configure #{os}-client idempotently" do
+          apply_manifest_on(client, client_manifest, catch_changes: true)
+        end
+      end
+
+      context 'server needs a test user with passwd' do
+        let(:test_user) { 'tst0_usr' }
+
+        it 'add test user' do
+          on(server, "puppet resource user #{test_user} ensure=present comment='Tst0 User'")
+          stdin = "#{password}\n" * 2
+          on(server, "passwd #{test_user} ", :stdin => stdin)
+        end
+      end
+
+      context 'Test /etc/pam.d/sshd oath through ssh' do
+        let(:test_user) { 'tst0_usr' }
+        let(:oath_key) { '000001' }
+        let(:bad_oath_key) { '1337' }
+        let(:bad_password) { 'h4x0r' }
+
+        it 'Copy test scripts to server' do
+          scp_to(client, File.join(files_dir, 'ssh_test_script'), '/usr/local/bin/ssh_test_script')
+          on(client, 'chmod u+x /usr/local/bin/ssh_test_script')
+          scp_to(client, File.join(files_dir, 'oath_ssh_test_script'), '/usr/local/bin/oath_ssh_test_script')
+          on(client, 'chmod u+x /usr/local/bin/oath_ssh_test_script')
+        end
+
+        it 'check that the test user can ssh' do
+          on(client, "/usr/local/bin/oath_ssh_test_script #{test_user} #{oath_key} #{password} #{os}-server")
+        end
+
+        it 'fail auth with bad TOTP' do
+          on(client, "/usr/local/bin/oath_ssh_test_script #{test_user} #{bad_oath_key} #{password} #{os}-server", :acceptable_exit_codes => [1])
+        end
+
+        it 'fail auth with good TOTP and bad pass' do
+          on(client, "/usr/local/bin/oath_ssh_test_script #{test_user} #{oath_key} #{bad_password} #{os}-server", :acceptable_exit_codes => [1])
+        end
+
+        it 'test user exclusion' do
+          on(server, "echo '#{test_user}' >> /etc/liboath/exclude_users.oath")
+          on(client, "/usr/local/bin/ssh_test_script #{test_user} #{os}-server #{password}")
+          # Clean up test_user out of exclude_users file
+          on(server, "echo 'vagrant' > /etc/liboath/exclude_users.oath")
+          on(server, "echo 'root' >> /etc/liboath/exclude_users.oath")
+        end
+
+        it 'test group exclusion' do
+          on(server, 'groupadd test_group')
+          on(server, "echo 'test_group' >> /etc/liboath/exclude_groups.oath")
+          on(server, "usermod -aG test_group #{test_user}")
+          on(client, "/usr/local/bin/ssh_test_script #{test_user} #{os}-server #{password}")
+          # Clean up test_user out of exclude_groups file
+          on(server, "echo '' > /etc/liboath/exclude_groups.oath")
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/files/oath_ssh_test_script
+++ b/spec/acceptance/suites/default/files/oath_ssh_test_script
@@ -1,0 +1,28 @@
+#!/usr/bin/expect -f
+
+set user [lindex $argv 0]
+set key  [lindex $argv 1]
+set pass [lindex $argv 2]
+set host [lindex $argv 3]
+set output [exec oathtool --totp $key]
+set timeout 10
+
+spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user
+
+expect {
+    "*One-time password*" {
+        send_user "One-time password"
+        send "$output\r"
+        expect "*assword:" {
+            send_user "password (for $user)"
+            send "$pass\r"
+            exp_continue
+        }
+        exp_continue
+    } -re "$user@.+\[\$#]*" {
+        send_user "TOTP test: success\n"
+        exit 0
+    }
+}
+send_user "TOTP test: failure\n"
+exit 1

--- a/spec/acceptance/suites/default/files/ssh_test_script
+++ b/spec/acceptance/suites/default/files/ssh_test_script
@@ -6,8 +6,10 @@ set pass [lindex $argv 2]
 set timeout 5
 
 spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user ssh -V
-expect "*password:" {
-  send "$pass\r"
+expect "*assword:" {
+    send "$pass\r"
+    catch wait result
+    exit [lindex $result 3]
 }
-catch wait result
-exit [lindex $result 3]
+send_user "\nAuthentication: Failed!\n"
+exit 255

--- a/spec/expected/conf_spec/el6_sshd_default
+++ b/spec/expected/conf_spec/el6_sshd_default
@@ -1,0 +1,16 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the
+# user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth

--- a/spec/expected/conf_spec/el6_sshd_dont_deny_root
+++ b/spec/expected/conf_spec/el6_sshd_dont_deny_root
@@ -1,0 +1,16 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the
+# user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth

--- a/spec/expected/conf_spec/el6_sshd_non_default
+++ b/spec/expected/conf_spec/el6_sshd_non_default
@@ -1,0 +1,16 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       required     pam_faillock.so preauth deny=10 audit unlock_time=300 fail_interval=400 even_deny_root root_unlock_time=30
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the
+# user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth

--- a/spec/expected/conf_spec/el6_sshd_oath_enabled
+++ b/spec/expected/conf_spec/el6_sshd_oath_enabled
@@ -1,0 +1,20 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
+auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
+auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=1
+auth       requisite    pam_deny.so
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the
+# user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth

--- a/spec/expected/conf_spec/el7_sshd_default
+++ b/spec/expected/conf_spec/el7_sshd_default
@@ -1,0 +1,21 @@
+#%PAM-1.0
+auth	   required	    pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/spec/expected/conf_spec/el7_sshd_dont_deny_root
+++ b/spec/expected/conf_spec/el7_sshd_dont_deny_root
@@ -1,0 +1,21 @@
+#%PAM-1.0
+auth	   required	    pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/spec/expected/conf_spec/el7_sshd_non_default
+++ b/spec/expected/conf_spec/el7_sshd_non_default
@@ -1,0 +1,21 @@
+#%PAM-1.0
+auth	   required	    pam_sepermit.so
+auth       required     pam_faillock.so preauth deny=10 audit unlock_time=300 fail_interval=400 even_deny_root root_unlock_time=30
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/spec/expected/conf_spec/el7_sshd_oath_enabled
+++ b/spec/expected/conf_spec/el7_sshd_oath_enabled
@@ -1,0 +1,25 @@
+#%PAM-1.0
+auth	   required	    pam_sepermit.so
+auth       required     pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
+auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
+auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=1
+auth       requisite    pam_deny.so
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/spec/fixtures/hieradata/dont_deny_root_pam_stack.yaml
+++ b/spec/fixtures/hieradata/dont_deny_root_pam_stack.yaml
@@ -1,0 +1,5 @@
+---
+simp_options::pam : true
+simp_options::oath : false
+ssh::server::conf::manage_pam_sshd : true
+ssh::server::conf::even_deny_root : false

--- a/spec/fixtures/hieradata/non_default_faillock_pam_stack.yaml
+++ b/spec/fixtures/hieradata/non_default_faillock_pam_stack.yaml
@@ -1,0 +1,10 @@
+---
+simp_options::pam : true
+simp_options::oath : false
+ssh::server::conf::manage_pam_sshd : true
+ssh::server::conf::display_account_lock : true
+ssh::server::conf::deny : 10 
+ssh::server::conf::unlock_time : 300
+ssh::server::conf::fail_interval : 400
+ssh::server::conf::even_deny_root : true
+ssh::server::conf::root_unlock_time : 30

--- a/spec/fixtures/hieradata/oath_enabled_pam_stack.yaml
+++ b/spec/fixtures/hieradata/oath_enabled_pam_stack.yaml
@@ -1,0 +1,3 @@
+---
+simp_options::pam: true
+simp_options::oath: true

--- a/templates/etc/pam.d/sshd_el6.epp
+++ b/templates/etc/pam.d/sshd_el6.epp
@@ -1,0 +1,25 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       required     pam_faillock.so preauth<% if
+$ssh::server::conf::display_account_lock == false { %> silent<% } %> deny=<%=
+$ssh::server::conf::deny %> audit unlock_time=<%=
+$ssh::server::conf::unlock_time %> fail_interval=<%=
+$ssh::server::conf::fail_interval %> <%- if $ssh::server::conf::even_deny_root == true { %> even_deny_root root_unlock_time=<%= $ssh::server::conf::root_unlock_time %><% } -%>
+<% if $ssh::server::conf::oath == true { %>
+auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
+auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $ssh::server::conf::oath_window %>
+auth       requisite    pam_deny.so<% } %>
+auth       include      password-auth
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the
+# user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth

--- a/templates/etc/pam.d/sshd_el6.epp
+++ b/templates/etc/pam.d/sshd_el6.epp
@@ -1,15 +1,11 @@
 #%PAM-1.0
 auth       required     pam_sepermit.so
-auth       required     pam_faillock.so preauth<% if
-$ssh::server::conf::display_account_lock == false { %> silent<% } %> deny=<%=
-$ssh::server::conf::deny %> audit unlock_time=<%=
-$ssh::server::conf::unlock_time %> fail_interval=<%=
-$ssh::server::conf::fail_interval %> <%- if $ssh::server::conf::even_deny_root == true { %> even_deny_root root_unlock_time=<%= $ssh::server::conf::root_unlock_time %><% } -%>
-<% if $ssh::server::conf::oath == true { %>
+<% if $ssh::server::conf::oath { -%>
 auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
 auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
 auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $ssh::server::conf::oath_window %>
-auth       requisite    pam_deny.so<% } %>
+auth       requisite    pam_deny.so
+<% } -%>
 auth       include      password-auth
 account    required     pam_nologin.so
 account    include      password-auth

--- a/templates/etc/pam.d/sshd_el7.epp
+++ b/templates/etc/pam.d/sshd_el7.epp
@@ -1,0 +1,30 @@
+#%PAM-1.0
+auth	   required	    pam_sepermit.so
+auth       required     pam_faillock.so preauth<% if
+$ssh::server::conf::display_account_lock == false { %> silent<% } %> deny=<%=
+$ssh::server::conf::deny %> audit unlock_time=<%=
+$ssh::server::conf::unlock_time %> fail_interval=<%=
+$ssh::server::conf::fail_interval %> <%- if $ssh::server::conf::even_deny_root == true { %> even_deny_root root_unlock_time=<%= $ssh::server::conf::root_unlock_time %><% } -%>
+<% if $ssh::server::conf::oath == true { %>
+auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
+auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $ssh::server::conf::oath_window %>
+auth       requisite    pam_deny.so<% } %>
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/templates/etc/pam.d/sshd_el7.epp
+++ b/templates/etc/pam.d/sshd_el7.epp
@@ -1,15 +1,11 @@
 #%PAM-1.0
-auth	   required	    pam_sepermit.so
-auth       required     pam_faillock.so preauth<% if
-$ssh::server::conf::display_account_lock == false { %> silent<% } %> deny=<%=
-$ssh::server::conf::deny %> audit unlock_time=<%=
-$ssh::server::conf::unlock_time %> fail_interval=<%=
-$ssh::server::conf::fail_interval %> <%- if $ssh::server::conf::even_deny_root == true { %> even_deny_root root_unlock_time=<%= $ssh::server::conf::root_unlock_time %><% } -%>
-<% if $ssh::server::conf::oath == true { %>
+auth       required     pam_sepermit.so
+<% if $ssh::server::conf::oath { %>
 auth       [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
 auth       [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
 auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $ssh::server::conf::oath_window %>
-auth       requisite    pam_deny.so<% } %>
+auth       requisite    pam_deny.so
+<% } -%>
 auth       substack     password-auth
 auth       include      postlogin
 # Used with polkit to reauthorize users in remote sessions


### PR DESCRIPTION
* Set sshd passwordauthentication to false if oath is true
* Defaults passwordauthentication to true
* Template fixes and spec test additions
* Add acceptance test for oath
* Differentiate the EL6 and EL7 pam stacks
* Fix illegal ssh_config setting RequestTTY in acceptance test
* Added optional dependency of oath

SIMP-5324 #comment Committed ssh portion of oath update.
This will break if pupmod-simp-oath PR has not been commited.