### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,11 +5,7 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,11 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.6.0-0
+- Expanded the upper limit of the stdlib Puppet module version
+- Updated URLs in the README.md
+
 * Tue Dec 04 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.6.0-0
-- Fix bug in which the sshd 'Subsystem' configuration specified by 
+- Fix bug in which the sshd 'Subsystem' configuration specified by
   ssh::server::conf::subsystem was erroneously stripped of whitespace
-  
+
 * Thu Nov 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.6.0-0
 - Added a new class, ssh::authorized_keys, that consumes a hash of ssh pubkeys
   - Users are meant to be able to paste the output of their pubkey into hiera

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/pupmod-simp-ssh.svg)](https://travis-ci.org/simp/pupmod-simp-ssh) [![SIMP compatibility](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)](https://img.shields.io/badge/SIMP%20compatibility-4.2.*%2F5.1.*-orange.svg)
-
+[![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/ssh.svg)](https://forge.puppetlabs.com/simp/ssh)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/ssh.svg)](https://forge.puppetlabs.com/simp/ssh)
+[![Build Status](https://travis-ci.org/simp/pupmod-simp-ssh.svg)](https://travis-ci.org/simp/pupmod-simp-ssh)
 
 # SSH
 
@@ -385,5 +388,5 @@ Some environment variables may be useful:
 [aug_ssh]: https://github.com/hercules-team/augeasproviders_ssh/
 [aug_ssh__ssh_config]: https://github.com/hercules-team/augeasproviders_ssh#ssh_config-provider
 [aug_ssh__sshd_config]: https://github.com/hercules-team/augeasproviders_ssh#sshd_config-provider
-[simp_contrib]: simp.readthedocs.io/en/master/contributors_guide/
+[simp_contrib]: simp.readthedocs.io/en/stable/contributors_guide/
 [fips_mode]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the stdlib Puppet module version
- Updated URLs in the README.md

SIMP-6213 #comment pupmod-simp-ssh