### PR TITLE
(SIMP-6121) Convert to_string() calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.6.1-0
+- Use Puppet String in lieu of simplib's deprecated Puppet 3 to_string
+- Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.6.0-0
 - Expanded the upper limit of the stdlib Puppet module version
 - Updated URLs in the README.md

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -294,8 +294,8 @@ class ssh::server::conf (
   sshd_config { 'Banner'                          : value => $banner }
   sshd_config { 'ChallengeResponseAuthentication' : value => ssh::config_bool_translate($challengeresponseauthentication) }
   sshd_config { 'Ciphers'                         : value => $_ciphers }
-  sshd_config { 'ClientAliveInterval'             : value => to_string($clientaliveinterval) }
-  sshd_config { 'ClientAliveCountMax'             : value => to_string($clientalivecountmax) }
+  sshd_config { 'ClientAliveInterval'             : value => String($clientaliveinterval) }
+  sshd_config { 'ClientAliveCountMax'             : value => String($clientalivecountmax) }
   sshd_config { 'Compression'                     : value => ssh::config_bool_translate($compression) }
   sshd_config { 'GSSAPIAuthentication'            : value => ssh::config_bool_translate($gssapiauthentication) }
   sshd_config { 'HostbasedAuthentication'         : value => ssh::config_bool_translate($hostbasedauthentication) }
@@ -307,7 +307,7 @@ class ssh::server::conf (
   sshd_config { 'PermitEmptyPasswords'            : value => ssh::config_bool_translate($permitemptypasswords) }
   sshd_config { 'PermitRootLogin'                 : value => ssh::config_bool_translate($permitrootlogin) }
   sshd_config { 'PermitUserEnvironment'           : value => ssh::config_bool_translate($permituserenvironment) }
-  sshd_config { 'Port'                            : value => to_string($port) }
+  sshd_config { 'Port'                            : value => String($port) }
   sshd_config { 'PrintLastLog'                    : value => ssh::config_bool_translate($printlastlog) }
   sshd_config { 'Protocol'                        : value => $_protocol }
 
@@ -373,7 +373,7 @@ class ssh::server::conf (
   if $tcpwrappers {
     include '::tcpwrappers'
     tcpwrappers::allow { 'sshd':
-      pattern => nets2ddq($trusted_nets),
+      pattern => simplib::nets2ddq($trusted_nets),
       order   => 1
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Use Puppet String in lieu of simplib's deprecated Puppet 3 to_string
- Use simplib::nets2ddq in lieu of deprecated Puppet 3 nets2ddq

SIMP-6121 #close