### PR TITLE
(SIMP-6890) Add multi-port support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Jul 30 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.8.0-0
+- Add multiple port support
+  - The ssh::server::conf::port entry can now take an Array of ports
+  - `selinux_port` resources are created for each non-standard entry
+- Update the required version of simp-beaker-helpers to work around Highline
+  issues in the compliance acceptance tests.
+
 * Mon Jun 03 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 6.8.0-0
 - Add v2 compliance_markup data
 - Add support for puppetlabs-stdlib 6

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.14.1', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.14.4', '< 2.0.0'])
 end

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,6 +31,13 @@
 * [`ssh_autokey`](#ssh_autokey): Generates a random RSA SSH private and public key pair for a passed user.
 * [`ssh_global_known_hosts`](#ssh_global_known_hosts): **DEPRECATED**
 
+**Data types**
+
+* [`Ssh::Authentications`](#sshauthentications): Valid SSH Authentication Settings
+* [`Ssh::Loglevel`](#sshloglevel): Valid SSH Loglevels
+* [`Ssh::PermitRootLogin`](#sshpermitrootlogin): Valid Settings for PermitRootLogin
+* [`Ssh::Syslogfacility`](#sshsyslogfacility): Valid SSH Syslog Facility Settings
+
 ## Classes
 
 ### ssh
@@ -85,7 +92,8 @@ ssh::authorized_keys::keys:
   - ssh-rsa sajhgfsaihd...
   - ssh-rsa jrklsahsgfs...
   mike:
-    key: ssh-rsa dlfkjsahh...
+    key: dlfkjsahh...
+    type: ssh-rsa
     user: mlast
     target: /home/gitlab-runner/.ssh/authorized_keys
 ```
@@ -451,7 +459,7 @@ Default value: `false`
 
 ##### `port`
 
-Data type: `Simplib::Port`
+Data type: `Variant[Array[Simplib::Port],Simplib::Port]`
 
 Specifies the port number SSHD listens on.
 
@@ -498,7 +506,7 @@ Default value: `true`
 
 Data type: `String`
 
-Configures and external subsystem for file transfers.
+Configures an external subsystem for file transfers.
 
 Default value: 'sftp /usr/libexec/openssh/sftp-server'
 
@@ -530,7 +538,7 @@ Default value: simplib::lookup('simp_options::pam', { 'default_value' => true })
 
 Data type: `Boolean`
 
-Flag indicating whether or not to mangae the pam stack for sshd. This is
+Flag indicating whether or not to manage the pam stack for sshd. This is
 required for the oath option to work properly.
 
 Default value: $oath
@@ -1675,4 +1683,30 @@ This function takes one argument, expire time which is specified in days.
 Default expire time is 7 days. Set to '0' to never p
 
 Returns: `None`
+
+## Data types
+
+### Ssh::Authentications
+
+Valid SSH Authentication Settings
+
+Alias of `Enum['publickey', 'hostbased', 'keyboard-interactive', 'password', 'gssapi-with-mic']`
+
+### Ssh::Loglevel
+
+Valid SSH Loglevels
+
+Alias of `Enum['QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE', 'DEBUG', 'DEBUG1', 'DEBUG2', 'DEBUG3']`
+
+### Ssh::PermitRootLogin
+
+Valid Settings for PermitRootLogin
+
+Alias of `Variant[Boolean, Enum['prohibit-password', 'without-password', 'forced-commands-only']]`
+
+### Ssh::Syslogfacility
+
+Valid SSH Syslog Facility Settings
+
+Alias of `Enum['DAEMON', 'USER', 'AUTH', 'AUTHPRIV', 'LOCAL0', 'LOCAL1', 'LOCAL2', 'LOCAL3', 'LOCAL4', 'LOCAL5', 'LOCAL6', 'LOCAL7']`
 

--- a/spec/acceptance/suites/compliance/00_default_spec.rb
+++ b/spec/acceptance/suites/compliance/00_default_spec.rb
@@ -35,7 +35,8 @@ describe 'ssh STIG enforcement' do
 
   let(:hieradata) { <<-EOF
 ---
-ssh::server::conf::app_pki_external_source: '/etc/pki/simp-testing/pki'
+simp_options::pki: true
+simp_options::pki::source: '/etc/pki/simp-testing/pki'
 # This is for Beaker
 ssh::server::conf::permitrootlogin: true
 compliance_markup::enforcement:

--- a/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
+++ b/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper_acceptance'
+require_relative '../../support/lib/helpers/dump_sshd_ciphers'
+
+test_name 'ssh non-standard ports'
+
+describe 'ssh class' do
+
+  target_ports = [22, 2222, 22222]
+
+  # NOTE: by default, include 'ssh' will automatically include the ssh_server
+  let(:server_manifest) { "include 'ssh::server'" }
+
+  let(:server_hieradata) do
+    {
+      'simp_options::trusted_nets'                => ['ALL'],
+      'ssh::server::conf::banner'                 => '/dev/null',
+      'ssh::server::conf::permitrootlogin'        => true,
+      'ssh::server::conf::passwordauthentication' => true,
+      'ssh::server::conf::port'                  => target_ports
+    }
+  end
+
+  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+
+  context 'backup config prior to execution' do
+    # Back up all of the SSH configuration files prior to editing
+    block_on(hosts, :run_in_parallel => true) do |host|
+      on(host, '/bin/cp -ra /etc/ssh /root')
+    end
+  end
+
+  hosts_as('server').each do |_server|
+    os = _server.hostname.split('-').first
+    context "on #{os}:" do
+
+      let(:server) { _server }
+
+      let(:client) do
+        os = server.hostname.split('-').first
+        hosts_as('client').select { |x| x.hostname =~ /^#{os}-.+/ }.first
+      end
+
+      it 'should configure server with no errors' do
+        set_hieradata_on(server, server_hieradata)
+        apply_manifest_on(server, server_manifest, expect_changes: true)
+      end
+
+      it "should configure #{os}-server idempotently" do
+        apply_manifest_on(server, server_manifest, catch_changes: true)
+      end
+
+      it 'should create a user for the test' do
+        #create a test user and set a password
+        on(hosts, 'useradd non_standard_user', accept_all_exit_codes: true)
+        on(hosts, 'echo password | passwd non_standard_user --stdin')
+      end
+
+      it 'should be able to log in with just a key' do
+        # copy the key to local_keys
+        scp_to(server, File.join(files_dir, 'id_rsa_pub.example'), '/etc/ssh/local_keys/non_standard_user')
+        on(server, 'chmod o+r /etc/ssh/local_keys/non_standard_user')
+
+        on(client, "su non_standard_user -c 'mkdir /home/non_standard_user/.ssh'")
+        scp_to(client, File.join(files_dir, 'id_rsa_pub.example'), '/home/non_standard_user/.ssh/id_rsa.pub')
+        scp_to(client, File.join(files_dir, 'id_rsa.example'), '/home/non_standard_user/.ssh/id_rsa')
+        on(client, 'chown -R non_standard_user:non_standard_user /home/non_standard_user')
+      end
+
+      target_ports.each do |port|
+        context "using port #{port}" do
+          let(:ssh_cmd) do
+            "ssh -p #{port} -o StrictHostKeyChecking=no -i ~non_standard_user/.ssh/id_rsa non_standard_user@#{os}-server"
+          end
+
+          it "should be able to log in via port #{port}" do
+            on(client, "#{ssh_cmd} echo Logged in successfully")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/10_pam_oath_spec.rb
+++ b/spec/acceptance/suites/default/10_pam_oath_spec.rb
@@ -59,6 +59,8 @@ describe 'ssh check oath' do
 
           set_hieradata_on(server, server_hieradata)
           apply_manifest_on(server, server_manifest, expect_changes: true)
+          # Work around a bug in augeasproviders_ssh
+          apply_manifest_on(server, server_manifest, catch_failures: true)
         end
 
         it "should configure #{os}-server idempotently" do

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -54,7 +54,7 @@ describe 'ssh::server::conf' do
           it { is_expected.to contain_sshd_config('IgnoreUserKnownHosts').with_value('yes') }
           it { is_expected.to contain_sshd_config('KerberosAuthentication').with_value('no') }
           it { is_expected.to_not contain_sshd_config('KexAlgorithms') }
-          it { is_expected.to contain_sshd_config('Port').with_value('22') }
+          it { is_expected.to contain_sshd_config('Port').with_value([22]) }
           it { is_expected.to contain_sshd_config('PermitEmptyPasswords').with_value('no') }
           it { is_expected.to contain_sshd_config('PermitRootLogin').with_value('no') }
           it { is_expected.to contain_sshd_config('PermitUserEnvironment').with_value('no') }

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -343,6 +343,7 @@ describe 'ssh::server::conf' do
           let(:facts) { os_facts.merge( { :openssh_version => '7.4'} ) }
           let(:params) {{ :port => 22000 }}
 
+          it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_package('policycoreutils-python') }
 
           it { is_expected.to contain_selinux_port("tcp_#{params[:port]}-#{params[:port]}").with(
@@ -355,6 +356,31 @@ describe 'ssh::server::conf' do
           }
 
           it { is_expected.to contain_selinux_port("tcp_#{params[:port]}-#{params[:port]}").that_requires('Package[policycoreutils-python]') }
+        end
+
+        context "with multiple SSH ports" do
+          let(:facts) { os_facts.merge( { :openssh_version => '7.4'} ) }
+          let(:params) {{ :port => [22000, 22, 22222] }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to_not contain_selinux_port("tcp_#{params[:port][1]}-#{params[:port][1]}") }
+
+          it { is_expected.to contain_selinux_port("tcp_#{params[:port].first}-#{params[:port].first}").with(
+            {
+              :low_port  => params[:port].first,
+              :high_port => params[:port].first,
+              :seltype   => 'ssh_port_t',
+              :protocol  => 'tcp'
+            })
+          }
+          it { is_expected.to contain_selinux_port("tcp_#{params[:port].last}-#{params[:port].last}").with(
+            {
+              :low_port  => params[:port].last,
+              :high_port => params[:port].last,
+              :seltype   => 'ssh_port_t',
+              :protocol  => 'tcp'
+            })
+          }
         end
       end
     end

--- a/types/authentications.pp
+++ b/types/authentications.pp
@@ -1,2 +1,8 @@
-type Ssh::Authentications = Enum['publickey', 'hostbased',
-  'keyboard-interactive', 'password', 'gssapi-with-mic']
+# Valid SSH Authentication Settings
+type Ssh::Authentications = Enum[
+  'publickey',
+  'hostbased',
+  'keyboard-interactive',
+  'password',
+  'gssapi-with-mic'
+]

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,2 +1,12 @@
-type Ssh::Loglevel = Enum['QUIET', 'FATAL', 'ERROR', 'INFO', 'VERBOSE',
-  'DEBUG', 'DEBUG1', 'DEBUG2', 'DEBUG3']
+# Valid SSH Loglevels
+type Ssh::Loglevel = Enum[
+  'QUIET',
+  'FATAL',
+  'ERROR',
+  'INFO',
+  'VERBOSE',
+  'DEBUG',
+  'DEBUG1',
+  'DEBUG2',
+  'DEBUG3'
+]

--- a/types/permitrootlogin.pp
+++ b/types/permitrootlogin.pp
@@ -1,3 +1,4 @@
+# Valid Settings for PermitRootLogin
 type Ssh::PermitRootLogin = Variant[
   Boolean,
   Enum['prohibit-password', 'without-password', 'forced-commands-only']

--- a/types/syslogfacility.pp
+++ b/types/syslogfacility.pp
@@ -1,3 +1,16 @@
-type Ssh::Syslogfacility = Enum['DAEMON', 'USER', 'AUTH', 'AUTHPRIV', 'LOCAL0',
-  'LOCAL1', 'LOCAL2', 'LOCAL3', 'LOCAL4', 'LOCAL5', 'LOCAL6', 'LOCAL7']
+# Valid SSH Syslog Facility Settings
+type Ssh::Syslogfacility = Enum[
+  'DAEMON',
+  'USER',
+  'AUTH',
+  'AUTHPRIV',
+  'LOCAL0',
+  'LOCAL1',
+  'LOCAL2',
+  'LOCAL3',
+  'LOCAL4',
+  'LOCAL5',
+  'LOCAL6',
+  'LOCAL7'
+]
 


### PR DESCRIPTION
- Add multiple port support
  - The ssh::server::conf::port entry can now take an Array of ports
  - `selinux_port` resources are created for each non-standard entry
- Update the required version of simp-beaker-helpers to work around Highline
  issues in the compliance acceptance tests.

SIMP-6890 #close