### PR TITLE
 (SIMP-6844) Correct simp-ssh documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ ssh::server::conf::port: 2222
 ssh::server::conf::ciphers:
 - 'chacha20-poly1305@openssh.com'
 - 'aes256-ctr'
-- 'aes256-gcm@openssh.com
+- 'aes256-gcm@openssh.com'
 ssh::server::conf::ssh_loglevel: "verbose"
 ssh::server::conf::gssapiauthentication: true
 ```

--- a/README.md
+++ b/README.md
@@ -193,9 +193,17 @@ ssh::server::conf::port: 2222
 ssh::server::conf::ciphers:
 - 'chacha20-poly1305@openssh.com'
 - 'aes256-ctr'
-- 'aes256-gcm@openssh.com'
+- 'aes256-gcm@openssh.com
 ssh::server::conf::ssh_loglevel: "verbose"
 ssh::server::conf::gssapiauthentication: true
+```
+
+```puppet
+include 'ssh::server'
+
+# Alternative:
+# if `ssh::enable_server: true`, this will also work
+include 'ssh'
 ```
 
 #### Managing additional server settings

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -424,11 +424,10 @@ Default value: 6
 
 Data type: `Boolean`
 
-Enable password authentication on the sshd server. If set to undef, this
-setting will not be managed.
+Specifies whether password authentication is allowed on the sshd server.
 
-* Note: This setting must be managed by default so that switching to and
-  from OATH does not lock you out of your system.
+* This setting must be managed by default so that switching to and from
+  OATH does not lock you out of your system.
 
 Default value: `true`
 
@@ -551,10 +550,6 @@ Data type: `Boolean`
 Configures ssh to use pam_oath TOTP in the sshd pam stack.
 Also configures sshd_config to use required settings. Inherits from
 simp_options::oath, defaults to false if not found.
-
-* WARNING: If this setting is enabled then disabled and
-  passwordauthentication is unmanaged, this will be set to no
-  in sshd_config!
 
 Default value: simplib::lookup('simp_options::oath', { 'default_value' => false })
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -107,11 +107,7 @@
 #   connection.
 #
 # @param passwordauthentication
-#   Enable password authentication on the sshd server. If set to undef, this
-#   setting will not be managed.
-#
-#   * Note: This setting must be managed by default so that switching to and
-#     from OATH does not lock you out of your system.
+#   Specifies whether password authentication is allowed on the sshd server.
 #
 # @param permitemptypasswords
 #   When password authentication is allowed, it specifies whether the server
@@ -164,10 +160,6 @@
 #   Configures ssh to use pam_oath TOTP in the sshd pam stack.
 #   Also configures sshd_config to use required settings. Inherits from
 #   simp_options::oath, defaults to false if not found.
-#
-#   * WARNING: If this setting is enabled then disabled and
-#     passwordauthentication is unmanaged, this will be set to no
-#     in sshd_config!
 #
 # @param oath_window
 #   Sets the TOTP window (Defined in RFC 6238 section 5.2)

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -109,6 +109,9 @@
 # @param passwordauthentication
 #   Specifies whether password authentication is allowed on the sshd server.
 #
+#   * This setting must be managed by default so that switching to and from
+#     OATH does not lock you out of your system.
+#
 # @param permitemptypasswords
 #   When password authentication is allowed, it specifies whether the server
 #   allows login to accounts with empty password strings.


### PR DESCRIPTION
Parameter passwordauthenication is no longer optional, update
documentation to reflect

SIMP-6844 #close