### PR TITLE
(SIMP-MAINT) Fixed issue with duplicate packages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Aug 06 2019 Michael Morrone <michael.morrone@@onyxpoint.com> - 6.8.1-0
+- Removed ensure from policycoreutils-python in server config for
+  multiple port support to elimate duplicate declaration
+
 * Tue Jul 30 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.8.0-0
 - Add multiple port support
   - The ssh::server::conf::port entry can now take an Array of ports

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -526,9 +526,7 @@ class ssh::server::conf (
     if $sel_port != 22 and $facts['selinux_enforced'] {
       simplib::assert_optional_dependency($module_name, 'simp/vox_selinux')
 
-      $_policy_pkg_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
-
-      ensure_packages(['policycoreutils-python'], {ensure => $_policy_pkg_ensure} )
+      ensure_packages(['policycoreutils-python'])
 
       selinux_port { "tcp_${sel_port}-${sel_port}":
         low_port  => $sel_port,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
Multiple ports with SELinux caused a duplicate resource declaration
  of policycoreutils-python, which was already required by vox-selinux