### PR TITLE
(SIMP-7006) ssh::server::conf allow removal of entries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,13 +163,13 @@ pup5.5.10:
   <<: *pup_5_5_10
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default,default]'
 
 pup5.5.10-fips:
   <<: *pup_5_5_10
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
 pup5.5.10-oel:
   <<: *pup_5_5_10
@@ -188,10 +188,22 @@ pup6:
   <<: *pup_6
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default,default]'
 
 pup6-fips:
   <<: *pup_6
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+
+pup5.5.10-fips-compliance:
+  <<: *pup_5_5_10
+  <<: *compliance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'
+
+pup6-fips-compliance:
+  <<: *pup_6
+  <<: *compliance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
-* Fri Oct 18 2019 Kendall Moore <kendall.moore@onyxpoint.com> - 6.8.2-0
+* Thu Oct 24 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.9.0-0
+- Added two `ssh::server::conf` parameters to allow users to ensure
+  specific sshd configuration is removed from sshd_config:
+  - `ssh::server::conf::remove_entries`
+  - `ssh::server::conf::remove_subsystems`
+- Allow use of simp-simplib 4.X.
+
+* Fri Oct 18 2019 Kendall Moore <kendall.moore@onyxpoint.com> - 6.9.0-0
 - Updated the default Tunnel setting to 'no' in ssh_config to match the man page
 
 * Tue Aug 06 2019 Michael Morrone <michael.morrone@@onyxpoint.com> - 6.8.1-0

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,11 +23,12 @@
 
 **Functions**
 
+* [`ssh::add_sshd_config`](#sshadd_sshd_config): Add a sshd_config entry if it is not in the remove list
 * [`ssh::autokey`](#sshautokey): Generates a random RSA SSH private and public key pair for a passed
 * [`ssh::config_bool_translate`](#sshconfig_bool_translate): Translates true|false or 'true'|'false' to 'yes'|'no', respectively
 * [`ssh::format_host_entry_for_sorting`](#sshformat_host_entry_for_sorting): A method to sensibly format sort SSH 'host' entries which contain
 * [`ssh::global_known_hosts`](#sshglobal_known_hosts): Update the ssh_known_hosts files for all hosts, purging old files,
-* [`ssh::parse_ssh_pubkey`](#sshparse_ssh_pubkey): Taka an ssh pugkey that looks like:   ssh-rsa jdlkfgjsdfo;i... user@domain.com and turn it into a hash, usable in the ssh_authorized_key type
+* [`ssh::parse_ssh_pubkey`](#sshparse_ssh_pubkey): Take an ssh pubkey that looks like:   ssh-rsa jdlkfgjsdfo;i... user@domain.com and turn it into a hash, usable in the ssh_authorized_key type
 * [`ssh_autokey`](#ssh_autokey): Generates a random RSA SSH private and public key pair for a passed user.
 * [`ssh_global_known_hosts`](#ssh_global_known_hosts): **DEPRECATED**
 
@@ -593,6 +594,26 @@ without any validation.
   ---
   ssh::server::conf::custom_entries:
     AuthorizedPrincipalsCommand: '/usr/local/bin/my_auth_command'
+
+Default value: `undef`
+
+##### `remove_entries`
+
+Data type: `Optional[Array[String[1]]]`
+
+List of configuration parameters that will be removed.
+
+* NOTE: Due to complexity, ``Match`` entries are not supported and will
+  need to be removed using ``sshd_config_match`` resources as described in
+  ``augeasproviders_ssh``
+
+Default value: `undef`
+
+##### `remove_subsystems`
+
+Data type: `Optional[Array[String[1]]]`
+
+List of subsystems that will be removed.
 
 Default value: `undef`
 
@@ -1331,7 +1352,7 @@ Data type: `Enum['yes','no','point-to-point','ethernet']`
 If 'yes', request device forwarding between the client and
 server.
 
-Default value: 'yes'
+Default value: 'no'
 
 ##### `tunneldevice`
 
@@ -1425,6 +1446,36 @@ namevar
 The file that you wish to prune
 
 ## Functions
+
+### ssh::add_sshd_config
+
+Type: Puppet Language
+
+Add a sshd_config entry if it is not in the remove list
+
+#### `ssh::add_sshd_config(String[1] $key, Any $value, Variant[Array[String[1]],Undef] $remove_keys)`
+
+Add a sshd_config entry if it is not in the remove list
+
+Returns: `Nil`
+
+##### `key`
+
+Data type: `String[1]`
+
+The name of the sshd configuration parameter
+
+##### `value`
+
+Data type: `Any`
+
+The value of the sshd configuration parameter
+
+##### `remove_keys`
+
+Data type: `Variant[Array[String[1]],Undef]`
+
+List of sshd configuration parameters to be removed
 
 ### ssh::autokey
 
@@ -1603,13 +1654,13 @@ means never purge
 
 Type: Puppet Language
 
-Taka an ssh pugkey that looks like:
+Take an ssh pubkey that looks like:
   ssh-rsa jdlkfgjsdfo;i... user@domain.com
 and turn it into a hash, usable in the ssh_authorized_key type
 
 #### `ssh::parse_ssh_pubkey(String $key)`
 
-Taka an ssh pugkey that looks like:
+Take an ssh pubkey that looks like:
   ssh-rsa jdlkfgjsdfo;i... user@domain.com
 and turn it into a hash, usable in the ssh_authorized_key type
 

--- a/functions/add_sshd_config.pp
+++ b/functions/add_sshd_config.pp
@@ -1,0 +1,20 @@
+# Add a sshd_config entry if it is not in the remove list
+#
+# @param key The name of the sshd configuration parameter
+# @param value The value of the sshd configuration parameter
+# @param remove_keys List of sshd configuration parameters to be removed
+#
+# @return [Nil]
+#
+function ssh::add_sshd_config(
+  String[1]                       $key,
+  Any                             $value,
+  Variant[Array[String[1]],Undef] $remove_keys
+) {
+
+  $_add = ( $remove_keys == undef ) or ( !member($remove_keys, $key) )
+
+  if $_add {
+    sshd_config { $key: value => $value }
+  }
+}

--- a/functions/parse_ssh_pubkey.pp
+++ b/functions/parse_ssh_pubkey.pp
@@ -1,4 +1,4 @@
-# Taka an ssh pugkey that looks like:
+# Take an ssh pubkey that looks like:
 #   ssh-rsa jdlkfgjsdfo;i... user@domain.com
 # and turn it into a hash, usable in the ssh_authorized_key type
 #

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.8.2",
+  "version": "6.9.0",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.9.0 < 4.0.0"
+      "version_requirement": ">= 3.9.0 < 5.0.0"
     }
   ],
   "simp": {

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -5,7 +5,7 @@ describe 'ssh::server::conf' do
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       let(:facts) do
-        facts
+        os_facts
       end
 
       context "on os #{os}" do
@@ -381,6 +381,67 @@ describe 'ssh::server::conf' do
               :protocol  => 'tcp'
             })
           }
+        end
+
+        context 'with remove_entries set' do
+          let(:hieradata) { 'remove_entries' }
+
+          it { is_expected.to compile.with_all_deps }
+
+          # entries ssh::server::conf would normally set
+          it { is_expected.to contain_sshd_config('AcceptEnv').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AllowGroups').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AllowUsers').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommand').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommandUser').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommand').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommandUser').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommand').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysCommandUser').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('AuthorizedKeysFile').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('Banner').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('ChallengeResponseAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('Ciphers').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('ClientAliveInterval').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('ClientAliveCountMax').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('Compression').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('DenyGroups').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('DenyUsers').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('GSSAPIAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('HostbasedAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('KerberosAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('KexAlgorithms').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('IgnoreRhosts').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('IgnoreUserKnownHosts').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('ListenAddress').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('LoginGraceTime').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('LogLevel').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('MACs').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('MaxAuthTries').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('PasswordAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('PermitEmptyPasswords').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('PermitRootLogin').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('PermitUserEnvironment').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('Port').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('PrintLastLog').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('Protocol').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('RhostsRSAAuthentication').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('StrictModes').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('SyslogFacility').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('UsePAM').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('UsePrivilegeSeparation').with_ensure('absent') }
+          it { is_expected.to contain_sshd_config('X11Forwarding').with_ensure('absent') }
+
+          # other entries
+          it { is_expected.to contain_sshd_config('AuthorizedPrincipalsCommand').with_ensure('absent') }
+
+        end
+
+        context 'with remove_subsystems set' do
+          let(:hieradata) { 'remove_subsystems' }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_sshd_config_subsystem('imap').with_ensure('absent') }
         end
       end
     end

--- a/spec/fixtures/hieradata/remove_entries.yaml
+++ b/spec/fixtures/hieradata/remove_entries.yaml
@@ -1,0 +1,45 @@
+---
+ssh::server::conf::remove_entries:
+# entries ssh::server::conf would normally set
+  - AcceptEnv
+  - AllowGroups
+  - AllowUsers
+  - AuthorizedKeysCommand
+  - AuthorizedKeysCommandUser
+  # intentional duplicate
+  - AuthorizedKeysCommandUser
+  - AuthorizedKeysFile
+  - Banner
+  - ChallengeResponseAuthentication
+  - Ciphers
+  - ClientAliveInterval
+  - ClientAliveCountMax
+  - Compression
+  - DenyGroups
+  - DenyUsers
+  - GSSAPIAuthentication
+  - HostbasedAuthentication
+  - KerberosAuthentication
+  - KexAlgorithms
+  - IgnoreRhosts
+  - IgnoreUserKnownHosts
+  - ListenAddress
+  - LoginGraceTime
+  - LogLevel
+  - MACs
+  - MaxAuthTries
+  - PasswordAuthentication
+  - PermitEmptyPasswords
+  - PermitRootLogin
+  - PermitUserEnvironment
+  - Port
+  - PrintLastLog
+  - Protocol
+  - RhostsRSAAuthentication
+  - StrictModes
+  - SyslogFacility
+  - UsePAM
+  - UsePrivilegeSeparation
+  - X11Forwarding
+# other entries
+  - AuthorizedPrincipalsCommand

--- a/spec/fixtures/hieradata/remove_subsystems.yaml
+++ b/spec/fixtures/hieradata/remove_subsystems.yaml
@@ -1,0 +1,5 @@
+---
+ssh::server::conf::remove_subsystems:
+  - imap
+  # intentional duplicate
+  - imap

--- a/spec/functions/ssh/add_sshd_config_spec.rb
+++ b/spec/functions/ssh/add_sshd_config_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'ssh::add_sshd_config' do
+
+key_info = {
+  'string'  => [ 'AuthorizedKeysFile', '/etc/ssh/local_keys/%u' ],
+  'array'   => [ 'AcceptEnv', [ 'LANG', 'LC_CTYPE' ] ],
+  'integer' => [ 'ClientAliveCountMax', 0 ]
+}
+
+  context 'with undef remove_keys' do
+    key_info.each do |type,key_value|
+      it "should create sshd_config resource with #{type} value" do
+        key = key_value[0]
+        value = key_value[1]
+        is_expected.to run.with_params(key, value, nil)
+
+         # verify resource exists
+         resource = catalogue.resource('Sshd_config', key)
+         expect(resource).to_not be_nil
+         expect(resource.to_hash[:value]).to eq(value)
+      end
+    end
+  end
+
+  context 'with remove_keys no match' do
+    it 'should create sshd_config resource with value set' do
+      key = 'ClientAliveCountMax'
+      value = 1
+      remove_keys = [ 'AcceptEnv', 'AuthorizedKeysFile' ]
+      is_expected.to run.with_params(key, value, remove_keys)
+      resource = catalogue.resource('Sshd_config', key)
+      expect(resource).to_not be_nil
+      expect(resource.to_hash[:value]).to eq(value)
+    end
+  end
+
+  context 'with remove_keys match' do
+    it 'should not create sshd_config resource' do
+      key = 'ClientAliveCountMax'
+      value = 1
+      remove_keys = [ 'AcceptEnv', 'ClientAliveCountMax' ]
+      is_expected.to run.with_params(key, value, remove_keys)
+      resource = catalogue.resource('Sshd_config', key)
+      expect(resource).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- Added two `ssh::server::conf` parameters to allow users to ensure
  specific sshd configuration is removed from sshd_config:
  - `ssh::server::conf::remove_entries`
  - `ssh::server::conf::remove_subsystems`
- Allow use of simp-simplib 4.X.
- Break out compliance tests into the compliance stage in GitLab