### PR TITLE
(SIMP-8811) Do not set client HostKeyAlgorithms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Nov 25 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.11.2-0
+- No longer set HostKeyAlgorithms on the client configuration by default
+
 * Thu Nov 19 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.11.1-0
 - Migrate to the updated version of simp/selinux that allows for isolated
   package installation in support of the SELinux native types.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1054,12 +1054,12 @@ Default value: ``false``
 
 ##### `hostkeyalgorithms`
 
-Data type: `Array[String]`
+Data type: `Optional[Array[String]]`
 
 Specifies the host key algorithms that the
 client wants to use in order of preference.
 
-Default value: `['ssh-rsa','ssh-dss']`
+Default value: ``undef``
 
 ##### `hostkeyalias`
 

--- a/manifests/authorized_keys.pp
+++ b/manifests/authorized_keys.pp
@@ -28,6 +28,8 @@
 #
 # @see https://puppet.com/docs/puppet/5.5/types/ssh_authorized_key.html
 #
+# @author https://github.com/simp/pupmod-simp-ssh/graphs/contributors
+#
 class ssh::authorized_keys (
   Hash $keys = {},
 ) {

--- a/manifests/client/host_config_entry.pp
+++ b/manifests/client/host_config_entry.pp
@@ -244,7 +244,7 @@
 # @param xauthlocation Specifies the full pathname of the xauth
 #   program.
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com
+# @author https://github.com/simp/pupmod-simp-ssh/graphs/contributors
 #
 define ssh::client::host_config_entry (
   Stdlib::Absolutepath                                  $target                           = '/etc/ssh/ssh_config',
@@ -278,7 +278,7 @@ define ssh::client::host_config_entry (
   Boolean                                               $gssapitrustdns                   = false,
   Boolean                                               $hashknownhosts                   = true,
   Boolean                                               $hostbasedauthentication          = false,
-  Array[String]                                         $hostkeyalgorithms                = ['ssh-rsa','ssh-dss'],
+  Optional[Array[String]]                               $hostkeyalgorithms                = undef,
   Optional[String]                                      $hostkeyalias                     = undef,
   Optional[Simplib::Host]                               $hostname                         = undef,
   Boolean                                               $identitiesonly                   = false,
@@ -494,10 +494,6 @@ define ssh::client::host_config_entry (
       key   => 'HostbasedAuthentication',
       value => ssh::config_bool_translate($hostbasedauthentication),
     ;
-    "${_name}__HostKeyAlgorithms":
-      key   => 'HostKeyAlgorithms',
-      value => $hostkeyalgorithms,
-    ;
     "${_name}__IdentitiesOnly":
       key   => 'IdentitiesOnly',
       value => ssh::config_bool_translate($identitiesonly),
@@ -632,6 +628,15 @@ define ssh::client::host_config_entry (
     ssh_config{ "${_name}__GlobalKnownHostsFile":
       key    => 'GlobalKnownHostsFile',
       value  => $globalknownhostsfile.join(' '),
+      host   => $name,
+      target => $target,
+    }
+  }
+
+  if $hostkeyalgorithms{
+    ssh_config { "${_name}__HostKeyAlgorithms":
+      key   => 'HostKeyAlgorithms',
+      value => $hostkeyalgorithms,
       host   => $name,
       target => $target,
     }

--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -1,6 +1,6 @@
 # @summary Default parameters for the SSH client
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-ssh/graphs/contributors
 #
 class ssh::client::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 # @param enable_server  If true, set up an SSH server on the system.
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-ssh/graphs/contributors
 #
 class ssh (
   Boolean $enable_client = true,

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -3,7 +3,7 @@
 # * ``KexAlgorithm`` configuration was not added until openssh 5.7
 # * ``Curve`` exchange was not fully supported until openssh 6.5
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-ssh/graphs/contributors
 #
 class ssh::server::params {
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",

--- a/spec/defines/client/host_config_entry_spec.rb
+++ b/spec/defines/client/host_config_entry_spec.rb
@@ -53,7 +53,6 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__GSSAPITrustDns').with_value('no')
             is_expected.to contain_ssh_config('new_run__HashKnownHosts').with_value('yes')
             is_expected.to contain_ssh_config('new_run__HostbasedAuthentication').with_value('no')
-            is_expected.to contain_ssh_config('new_run__HostKeyAlgorithms').with_value(['ssh-rsa','ssh-dss'])
             is_expected.to contain_ssh_config('new_run__IdentitiesOnly').with_value('no')
             is_expected.to contain_ssh_config('new_run__KbdInteractiveAuthentication').with_value('yes')
             is_expected.to contain_ssh_config('new_run__LogLevel').with_value('INFO')
@@ -121,6 +120,7 @@ describe 'ssh::client::host_config_entry' do
             :dynamicforward        => '1.2.3.4:1022',
             :globalknownhostsfile  => ['/some/hosts/file1', '/some/hosts/file2'],
             :hostkeyalias          => 'some.alias',
+            :hostkeyalgorithms     => ['ssh-rsa', 'ssh-dss'],
             :hostname              => 'some.hostname',
             :identityfile          => '/some/identity/file',
             :kbdinteractivedevices => ['bsdauth','pam'],


### PR DESCRIPTION
Fixed:
  - No longer set HostKeyAlgorithms on the client configuration by default

[SIMP-8811] #close

[SIMP-8811]: https://simp-project.atlassian.net/browse/SIMP-8811