### PR TITLE
(SIMP-9393) ssh: default suite execute 0 examples

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,21 +9,28 @@ HOSTS:
   el7-server:
     roles:
       - default
+      - server
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
 
   el7-client:
+    roles:
+      - client
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
 
   el8-server:
+    roles:
+      - server
     platform: el-8-x86_64
     box: centos/8
     hypervisor: <%= hypervisor %>
 
   el8-client:
+    roles:
+      - client
     platform: el-8-x86_64
     box: centos/8
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -9,21 +9,28 @@ HOSTS:
   el7-server:
     roles:
       - default
+      - server
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>
 
   el7-client:
+    roles:
+      - client
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>
 
   el8-server:
+    roles:
+      - server
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
 
   el8-client:
+    roles:
+      - client
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>


### PR DESCRIPTION
Reinstate roles in nodesets so `host_as('server')` and `host_as('client')` return
appropriate nodes and the tests run.

SIMP-9393 #close