### PR TITLE
(SIMP-8932) Update ssh_config host entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Fri Feb 19 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.11.2
+- Openssh dropped support for SSH protocol 1 in version 8.0.
+  EL8 installs openssh v8 by default.
+  This fix checks the version of openssh when creating ssh_config host
+  entries and removes those values that are no longer used.
+
 * Wed Jan 13 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.11.2
 - Removed EL6 from supported OSes
 

--- a/manifests/client/host_config_entry.pp
+++ b/manifests/client/host_config_entry.pp
@@ -381,8 +381,6 @@ define ssh::client::host_config_entry (
     $_gssapiauthentication = false
   }
 
-  $_value = ssh::config_bool_translate($useprivilegedport)
-
   $_name = ssh::format_host_entry_for_sorting($name)
 
   ssh_config{
@@ -421,10 +419,6 @@ define ssh::client::host_config_entry (
     "${_name}__Compression":
       key   => 'Compression',
       value => ssh::config_bool_translate($compression),
-    ;
-    "${_name}__CompressionLevel":
-      key   => 'CompressionLevel',
-      value => String($compressionlevel),
     ;
     "${_name}__ConnectionAttempts":
       key   => 'ConnectionAttempts',
@@ -538,14 +532,6 @@ define ssh::client::host_config_entry (
       key   => 'PubkeyAuthentication',
       value => ssh::config_bool_translate($pubkeyauthentication),
     ;
-    "${_name}__RhostsRSAAuthentication":
-      key   => 'RhostsRSAAuthentication',
-      value => ssh::config_bool_translate($rhostsrsaauthentication),
-    ;
-    "${_name}__RSAAuthentication":
-      key   => 'RSAAuthentication',
-      value => ssh::config_bool_translate($rsaauthentication),
-    ;
     "${_name}__SendEnv":
       key   => 'SendEnv',
       value => $sendenv,
@@ -570,10 +556,6 @@ define ssh::client::host_config_entry (
       key   => 'Tunnel',
       value => $tunnel,
     ;
-    "${_name}__UsePrivilegedPort":
-      key   => 'UsePrivilegedPort',
-      value => ssh::config_bool_translate($useprivilegedport),
-    ;
     "${_name}__VerifyHostKeyDNS":
       key   => 'VerifyHostKeyDNS',
       value => $verifyhostkeydns,
@@ -585,6 +567,36 @@ define ssh::client::host_config_entry (
     "${_name}__XAuthLocation":
       key   => 'XAuthLocation',
       value => $xauthlocation,
+    ;
+  }
+
+  # The following options have been removed in openssh 8.0
+  if versioncmp($facts['openssh_version'], '8.0') <  0 {
+    $_ensure = 'present'
+  } else {
+    $_ensure = 'absent'
+  }
+  ssh_config{
+    default:
+      host   => $name,
+      target => $target,
+      ensure => $_ensure
+    ;
+    "${_name}__CompressionLevel":
+      key   => 'CompressionLevel',
+      value => String($compressionlevel),
+    ;
+    "${_name}__RhostsRSAAuthentication":
+      key   => 'RhostsRSAAuthentication',
+      value => ssh::config_bool_translate($rhostsrsaauthentication),
+    ;
+    "${_name}__RSAAuthentication":
+      key   => 'RSAAuthentication',
+      value => ssh::config_bool_translate($rsaauthentication),
+    ;
+    "${_name}__UsePrivilegedPort":
+        key   => 'UsePrivilegedPort',
+        value => ssh::config_bool_translate($useprivilegedport),
     ;
   }
 

--- a/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
+++ b/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
@@ -8,11 +8,15 @@ describe 'ssh class' do
   target_ports = [22, 2222, 22222]
 
   # NOTE: by default, include 'ssh' will automatically include the ssh_server
-  let(:server_manifest) { "include 'ssh::server'" }
+  # NOTE: Temporary including vox_selinux so the packages required for the selinux_port
+  #  custom type are installed.  See SIMP-9425 for more detail.
+  let(:server_manifest) { "include 'ssh::server'
+                           include vox_selinux" }
 
   let(:server_hieradata) do
     {
       'simp_options::trusted_nets'                => ['ALL'],
+      'simp_options::firewall'                    => true,
       'ssh::server::conf::banner'                 => '/dev/null',
       'ssh::server::conf::permitrootlogin'        => true,
       'ssh::server::conf::passwordauthentication' => true,

--- a/spec/acceptance/suites/default/10_pam_oath_spec.rb
+++ b/spec/acceptance/suites/default/10_pam_oath_spec.rb
@@ -51,7 +51,7 @@ describe 'ssh check oath' do
 
       context 'with default parameters' do
         it 'configures server with no errors' do
-          install_package(client, 'epel-release')
+          enable_epel_on(client)
           install_package(client, 'expect')
 
           set_hieradata_on(client, client_hieradata)

--- a/spec/acceptance/suites/default/files/ssh_test_script_change_pass
+++ b/spec/acceptance/suites/default/files/ssh_test_script_change_pass
@@ -21,7 +21,7 @@ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $use
 match_max 100000
 expect -exact "$user@$host's password: "
 send -- "$pass\r"
-expect -re "UNIX password: "
+expect -re "UNIX|Current password: "
 send -- "$pass\r"
 expect -exact "\r
 New password: "

--- a/spec/defines/client/host_config_entry_spec.rb
+++ b/spec/defines/client/host_config_entry_spec.rb
@@ -29,7 +29,6 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__Ciphers').with_value(expected_ciphers)
             is_expected.to contain_ssh_config('new_run__ClearAllForwardings').with_value('no')
             is_expected.to contain_ssh_config('new_run__Compression').with_value('yes')
-            is_expected.to contain_ssh_config('new_run__CompressionLevel').with_value('6')
             is_expected.to contain_ssh_config('new_run__ConnectionAttempts').with_value('1')
             is_expected.to contain_ssh_config('new_run__ConnectTimeout').with_value('0')
             is_expected.to contain_ssh_config('new_run__ControlMaster').with_value('no')
@@ -58,20 +57,39 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__Port').with_value('22')
             is_expected.to contain_ssh_config('new_run__PreferredAuthentications').with_value('publickey,hostbased,keyboard-interactive,password')
             is_expected.to contain_ssh_config('new_run__PubkeyAuthentication').with_value('yes')
-            is_expected.to contain_ssh_config('new_run__RhostsRSAAuthentication').with_value('no')
-            is_expected.to contain_ssh_config('new_run__RSAAuthentication').with_value('yes')
             is_expected.to contain_ssh_config('new_run__SendEnv').with_value(['LANG','LC_CTYPE','LC_NUMERIC','LC_TIME','LC_COLLATE','LC_MONETARY','LC_MESSAGES','LC_PAPER','LC_NAME', 'LC_ADDRESS', 'LC_TELEPHONE', 'LC_MEASUREMENT', 'LC_IDENTIFICATION' ,'LC_ALL'])
             is_expected.to contain_ssh_config('new_run__ServerAliveCountMax').with_value('3')
             is_expected.to contain_ssh_config('new_run__ServerAliveInterval').with_value('0')
             is_expected.to contain_ssh_config('new_run__StrictHostKeyChecking').with_value('ask')
             is_expected.to contain_ssh_config('new_run__TCPKeepAlive').with_value('yes')
             is_expected.to contain_ssh_config('new_run__Tunnel').with_value('no')
-            is_expected.to contain_ssh_config('new_run__UsePrivilegedPort').with_value('no')
             is_expected.to contain_ssh_config('new_run__VerifyHostKeyDNS').with_value('no')
             is_expected.to contain_ssh_config('new_run__VisualHostKey').with_value('no')
             is_expected.to contain_ssh_config('new_run__XAuthLocation').with_value('/usr/bin/xauth')
           }
 
+          context 'when  openssh_version < 8.0' do
+            let(:facts)  {
+              super().merge!({ :openssh_version => '7.4' })
+            }
+            it {
+              is_expected.to contain_ssh_config('new_run__UsePrivilegedPort').with_value('no')
+              is_expected.to contain_ssh_config('new_run__RhostsRSAAuthentication').with_value('no')
+              is_expected.to contain_ssh_config('new_run__RSAAuthentication').with_value('yes')
+              is_expected.to contain_ssh_config('new_run__CompressionLevel').with_value('6')
+            }
+          end
+          context 'when  openssh_version >= 8.0' do
+            let(:facts)  {
+              super().merge!({ :openssh_version => '8.0' })
+            }
+            it {
+              is_expected.to contain_ssh_config('new_run__UsePrivilegedPort').with_ensure('absent')
+              is_expected.to contain_ssh_config('new_run__RhostsRSAAuthentication').with_ensure('absent')
+              is_expected.to contain_ssh_config('new_run__RSAAuthentication').with_ensure('absent')
+              is_expected.to contain_ssh_config('new_run__CompressionLevel').with_ensure('absent')
+            }
+          end
           context 'when connected to an IPA domain' do
             let(:facts) {
               super().merge!(
@@ -139,7 +157,6 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__Ciphers').with_value(['aes128-ctr','aes192-ctr'])
             is_expected.to contain_ssh_config('new_run__ClearAllForwardings').with_value('no')
             is_expected.to contain_ssh_config('new_run__Compression').with_value('yes')
-            is_expected.to contain_ssh_config('new_run__CompressionLevel').with_value('6')
             is_expected.to contain_ssh_config('new_run__ConnectionAttempts').with_value('1')
             is_expected.to contain_ssh_config('new_run__ConnectTimeout').with_value('0')
             is_expected.to contain_ssh_config('new_run__ControlMaster').with_value('no')
@@ -169,15 +186,12 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__Port').with_value('22')
             is_expected.to contain_ssh_config('new_run__PreferredAuthentications').with_value('publickey,hostbased,keyboard-interactive,password')
             is_expected.to contain_ssh_config('new_run__PubkeyAuthentication').with_value('yes')
-            is_expected.to contain_ssh_config('new_run__RhostsRSAAuthentication').with_value('no')
-            is_expected.to contain_ssh_config('new_run__RSAAuthentication').with_value('yes')
             is_expected.to contain_ssh_config('new_run__SendEnv').with_value(['LANG','LC_CTYPE','LC_NUMERIC','LC_TIME','LC_COLLATE','LC_MONETARY','LC_MESSAGES','LC_PAPER','LC_NAME', 'LC_ADDRESS', 'LC_TELEPHONE', 'LC_MEASUREMENT', 'LC_IDENTIFICATION' ,'LC_ALL'])
             is_expected.to contain_ssh_config('new_run__ServerAliveCountMax').with_value('3')
             is_expected.to contain_ssh_config('new_run__ServerAliveInterval').with_value('0')
             is_expected.to contain_ssh_config('new_run__StrictHostKeyChecking').with_value('ask')
             is_expected.to contain_ssh_config('new_run__TCPKeepAlive').with_value('yes')
             is_expected.to contain_ssh_config('new_run__Tunnel').with_value('no')
-            is_expected.to contain_ssh_config('new_run__UsePrivilegedPort').with_value('no')
             is_expected.to contain_ssh_config('new_run__VerifyHostKeyDNS').with_value('no')
             is_expected.to contain_ssh_config('new_run__VisualHostKey').with_value('no')
             is_expected.to contain_ssh_config('new_run__XAuthLocation').with_value('/usr/bin/xauth')
@@ -200,6 +214,23 @@ describe 'ssh::client::host_config_entry' do
             is_expected.to contain_ssh_config('new_run__UserKnownHostsFile').with_value('/some/hosts/file3 /some/hosts/file4')
           }
 
+        end
+        context 'when  openssh_version < 8.0 and param set' do
+          let(:facts)  {
+            os_facts.merge({ :openssh_version => '7.4' })
+          }
+          let(:params) {{
+            :useprivilegedport       => true,
+            :rhostsrsaauthentication => true,
+            :rsaauthentication       => false,
+            :compressionlevel        => 2,
+          }}
+          it {
+            is_expected.to contain_ssh_config('new_run__UsePrivilegedPort').with_value('yes')
+            is_expected.to contain_ssh_config('new_run__RhostsRSAAuthentication').with_value('yes')
+            is_expected.to contain_ssh_config('new_run__RSAAuthentication').with_value('no')
+            is_expected.to contain_ssh_config('new_run__CompressionLevel').with_value('2')
+          }
         end
 
         _protocol_sets = [ 1, '2,1' ]


### PR DESCRIPTION
- openssh v8.0  dropped support for SSH protocol 1.  This
  fix checks the version of openssh installed and removes deprecated
  values.
- Changes had to be made to the tests for the following:
- Test for changes to crypto are failing on EL8 because of global crypto
  policy.  This test is temporarily bypassed until it is fixed in
  SIMP-9412
- OEL tests are failing because packages are not being installed.
  An update was put in simp-beaker-helpers to the enable_epel method
  to enable the repo on OEL systems.
- Alternate port tests are failing because selinux_port is not set up
  correctly.  SIMP-9425 was created to address this.  The vox_selinux
  module was included as a work around until this is fixed.
- simp_options::firewall was set to true in the alternate port test
  because OEL has the firewall on in the test default.  It was simpler
  to let the firewall setup of the module handle opening ports rather
  then trying to shut down the firewall.
- Updated some tests that needed to be tweaked for EL8 because test in
  results was slightly different.

SIMP-8932 #close