### PR TITLE
(SIMP-9412) SSH selinux_port errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Mar 02 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.11.2
+- Updated server::conf to include the voxpupuli selinux module when
+  calling selinux_port.  This will ensure the packages that selinux_port
+  needs are installed.
+- Added memory to the testing nodesets for EL8 because running selinux_port
+  was giving an out of memory error.
+
 * Fri Feb 19 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.11.2
 - Openssh dropped support for SSH protocol 1 in version 8.0.
   EL8 installs openssh v8 by default.

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.4', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.22.1', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -539,10 +539,12 @@ class ssh::server::conf (
         simplib::assert_optional_dependency($module_name, 'simp/selinux')
         simplib::assert_optional_dependency($module_name, 'simp/vox_selinux')
 
-        include selinux::install
+        include vox_selinux
+
       }
       else {
         simplib::assert_optional_dependency($module_name, 'puppet/selinux')
+        include selinux
       }
 
       selinux_port { "tcp_${sel_port}-${sel_port}":

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -27,6 +27,8 @@ HOSTS:
     platform: el-8-x86_64
     box: centos/8
     hypervisor: <%= hypervisor %>
+    options:
+      memory: 1024
 
   el8-client:
     roles:
@@ -34,6 +36,8 @@ HOSTS:
     platform: el-8-x86_64
     box: centos/8
     hypervisor: <%= hypervisor %>
+    options:
+      memory: 1024
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -27,6 +27,8 @@ HOSTS:
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
+    options:
+      memory: 1024
 
   el8-client:
     roles:
@@ -34,6 +36,8 @@ HOSTS:
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
+    options:
+      memory: 1024
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
+++ b/spec/acceptance/suites/default/05_non_standard_ports_spec.rb
@@ -7,11 +7,7 @@ describe 'ssh class' do
 
   target_ports = [22, 2222, 22222]
 
-  # NOTE: by default, include 'ssh' will automatically include the ssh_server
-  # NOTE: Temporary including vox_selinux so the packages required for the selinux_port
-  #  custom type are installed.  See SIMP-9425 for more detail.
-  let(:server_manifest) { "include 'ssh::server'
-                           include vox_selinux" }
+  let(:server_manifest) { "include 'ssh::server'"}
 
   let(:server_hieradata) do
     {

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -295,7 +295,7 @@ describe 'ssh::server::conf' do
           let(:params) {{ :port => 22000 }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('selinux::install') }
+          it { is_expected.to contain_class('vox_selinux') }
 
           it { is_expected.to contain_selinux_port("tcp_#{params[:port]}-#{params[:port]}").with(
             {


### PR DESCRIPTION
- Running selinux_port was failing when the voxpupuli selinux
  modules was not included. selinux_port requires the packages
  installed by the module.  Verified that including the module
  would not do anything by default except install the packages.
- Added memory to the EL8 test nodes.  Tests were consistently getting an
  out of memory error when selinux_port was called.  semanage,
  used by the selinux_port resource, allocates a lot of memory
  when loading the selinux policies it needs.

[SIMP-9412] #close

[SIMP-9412]: https://simp-project.atlassian.net/browse/SIMP-9412