### PR TITLE
WIP: (SIMP-7255) Add key-only OATH support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "herculesteam/augeasproviders_ssh",
-      "version_requirement": ">= 2.5.0 < 4.0.0"
+      "version_requirement": ">= 2.5.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/acceptance/suites/compliance/nodesets/default.yml
+++ b/spec/acceptance/suites/compliance/nodesets/default.yml
@@ -1,3 +1,10 @@
+<%
+  if ENV['BEAKER_HYPERVISOR']
+    hypervisor = ENV['BEAKER_HYPERVISOR']
+  else
+    hypervisor = 'vagrant'
+  end
+-%>
 HOSTS:
   el7:
     roles:
@@ -5,7 +12,7 @@ HOSTS:
       - el7
     platform:   el-7-x86_64
     box:        centos/7
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
     yum_repos:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -470,7 +470,7 @@ describe 'ssh::server::conf' do
             end
 
             let(:key_only_user_match) do
-              "Group #{params[:oath_key_only_users].join(',')}"
+              "User #{params[:oath_key_only_users].join(',')}"
             end
 
             it { is_expected.to compile.with_all_deps }

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -394,6 +394,100 @@ describe 'ssh::server::conf' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_sshd_config_subsystem('imap').with_ensure('absent') }
         end
+
+        context 'with oath enabled' do
+          let(:params) do
+            {
+              :oath => true
+            }
+          end
+
+          let(:pam_content) do
+            File.read("#{File.join(__dir__, File.basename(__FILE__, '.rb'))}_fixtures/pam_sshd_with_oath")
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('oath') }
+          it { is_expected.not_to create_file('/etc/liboath/ssh_pubkey_users.oath') }
+          it { is_expected.not_to create_file('/etc/liboath/ssh_pubkey_groups.oath') }
+          it {
+            is_expected.to create_file('/etc/pam.d/sshd')
+              .with_ensure('file')
+              .with_content(pam_content)
+          }
+
+          context 'oath_window=3' do
+            let(:params) do
+              {
+                :oath => true,
+                :oath_window => 3
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it {
+              window_mod = pam_content.gsub(/window=\d/, 'window=3')
+
+              is_expected.to create_file('/etc/pam.d/sshd')
+                .with_ensure('file')
+                .with_content(window_mod)
+            }
+          end
+
+          context 'key only groups' do
+            let(:params) do
+              {
+                :oath => true,
+                :oath_key_only_groups => ['foo', 'bar']
+              }
+            end
+
+            let(:key_only_group_match) do
+              "Group #{params[:oath_key_only_groups].join(',')}"
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it {
+              is_expected.to create_file('/etc/liboath/ssh_pubkey_groups.oath')
+                .with_content(%(#{params[:oath_key_only_groups].sort.join("\n")}\n))
+            }
+            it { is_expected.to create_sshd_config_match(key_only_group_match).with_ensure('present') }
+            it {
+              is_expected.to create_sshd_config('AuthenticationMethods for OATH Key Groups')
+                .with_ensure('present')
+                .with_condition(key_only_group_match)
+                .with_key('AuthenticationMethods')
+                .with_value('publickey,keyboard-interactive')
+            }
+          end
+
+          context 'key only users' do
+            let(:params) do
+              {
+                :oath => true,
+                :oath_key_only_users => ['bar', 'baz']
+              }
+            end
+
+            let(:key_only_user_match) do
+              "Group #{params[:oath_key_only_users].join(',')}"
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it {
+              is_expected.to create_file('/etc/liboath/ssh_pubkey_users.oath')
+                .with_content(%(#{params[:oath_key_only_users].sort.join("\n")}\n))
+            }
+            it { is_expected.to create_sshd_config_match(key_only_user_match).with_ensure('present') }
+            it {
+              is_expected.to create_sshd_config('AuthenticationMethods for OATH Key Users')
+                .with_ensure('present')
+                .with_condition(key_only_user_match)
+                .with_key('AuthenticationMethods')
+                .with_value('publickey,keyboard-interactive')
+            }
+          end
+        end
       end
     end
   end

--- a/spec/classes/server/conf_spec_fixtures/pam_sshd_with_oath
+++ b/spec/classes/server/conf_spec_fixtures/pam_sshd_with_oath
@@ -1,21 +1,13 @@
-<%- |
-  Boolean $enable_oath = false,
-  Integer $oath_window = 1
-| -%>
 #%PAM-1.0
 auth       required     pam_sepermit.so
-<% if $enable_oath { -%>
 auth       [success=5 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath quiet
 auth       [success=4 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath quiet
-auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $oath_window %>
+auth       [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=1
 auth       requisite    pam_deny.so
 auth       [success=2 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/ssh_pubkey_groups.oath quiet
 auth       [success=1 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/ssh_pubkey_users.oath quiet
-<% } -%>
 auth       substack     password-auth
-<% if $enable_oath { -%>
 auth       required     pam_env.so
-<% } -%>
 auth       include      postlogin
 # Used with polkit to reauthorize users in remote sessions
 -auth      optional     pam_reauthorize.so prepare


### PR DESCRIPTION
Added:
  * Adds support for users and groups that only use OATH+SSH keys for
    authenticating to systems.

SIMP-7255 #close