### PR TITLE
(SIMP-9281) ssh: update augeasproviders_ssh

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,39 +1,39 @@
 ---
 fixtures:
   repositories:
-    auditd: https://github.com/simp/pupmod-simp-auditd
+    auditd: https://github.com/simp/pupmod-simp-auditd.git
     augeas_core:
       repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
-    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat: https://github.com/simp/puppetlabs-concat
-    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld
-    haveged: https://github.com/simp/pupmod-simp-haveged
-    iptables: https://github.com/simp/pupmod-simp-iptables
-    logrotate: https://github.com/simp/pupmod-simp-logrotate
-    oath: https://github.com/simp/pupmod-simp-oath
-    oddjob: https://github.com/simp/pupmod-simp-oddjob
-    pam: https://github.com/simp/pupmod-simp-pam
-    pki: https://github.com/simp/pupmod-simp-pki
-    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    stdlib: https://github.com/simp/puppetlabs-stdlib
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
-    selinux: https://github.com/simp/pupmod-simp-selinux
-    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh.git
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
+    concat: https://github.com/simp/puppetlabs-concat.git
+    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
+    haveged: https://github.com/simp/pupmod-simp-haveged.git
+    iptables: https://github.com/simp/pupmod-simp-iptables.git
+    logrotate: https://github.com/simp/pupmod-simp-logrotate.git
+    oath: https://github.com/simp/pupmod-simp-oath.git
+    oddjob: https://github.com/simp/pupmod-simp-oddjob.git
+    pam: https://github.com/simp/pupmod-simp-pam.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
+    rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
+    simp_options: https://github.com/simp/pupmod-simp-simp_options.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
+    selinux: https://github.com/simp/pupmod-simp-selinux.git
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     sshkeys_core:
       repo: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git
       puppet_version: ">= 6.0.0"
-    systemd: https://github.com/simp/puppet-systemd
+    systemd: https://github.com/simp/puppet-systemd.git
     vox_selinux:
-      repo: https://github.com/simp/pupmod-voxpupuli-selinux
+      repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
     disa_stig-el7-baseline:
-      repo: https://github.com/simp/inspec-profile-disa_stig-el7
+      repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch:  master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles
   symlinks:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Apr 20 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.11.3
+- Update to augeasproviders_ssh < 5.0.0
+
 * Tue Apr 20 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.11.2
 - Fixed a bug where some changes to sshd configuration did not cause the
   sshd service to restart.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.11.2",
+  "version": "6.11.3",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "herculesteam/augeasproviders_ssh",
-      "version_requirement": ">= 2.5.0 < 4.0.0"
+      "version_requirement": ">= 2.5.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
- Update to augeasproviders_ssh < 5.0.0. Version was bumped to 4.0.0 because
  the module dropped support for Augeas < 1.0.0.  This does not affect our modules.
- Make sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URL
- Configure the acceptance test to fail if rspec reports 0 examples. This
  detects some error cases related to bad nodesets.

[SIMP-9281] #comment pupmod-simp-ssh update augeasproviders_ssh
[SIMP-9666] #comment pupmod-simp-ssh acceptance tests configured

[SIMP-9281]: https://simp-project.atlassian.net/browse/SIMP-9281
[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666