### PR TITLE
(#143) Added parameter to ignore authorizedkeysfile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Nov 29 2021 Mike Riddle <mike@sicura.us> - 6.13.0
+- Added an option to turn off managing the AuthorizedKeysFile parameter
+  in /etc/ssh/sshd_config
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.12.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -18,6 +18,10 @@
 #   A list of user name patterns. If specified, login is allowed only for users
 #   whose name matches one of the patterns.
 #
+# @param manage_authorizedkeysfile
+#   This will allow users to opt out of puppet managing their ssh authorized 
+#   keys file. If set to false, authorizedkeysfile will be ignored.
+#
 # @param authorizedkeysfile
 #   This is set to a non-standard location to provide for increased control
 #   over who can log in as a given user.
@@ -259,6 +263,7 @@ class ssh::server::conf (
   Array[String]                                          $acceptenv                       = $ssh::server::params::acceptenv,
   Optional[Array[String]]                                $allowgroups                     = undef,
   Optional[Array[String]]                                $allowusers                      = undef,
+  Boolean                                                $manage_authorizedkeysfile       = true,
   String                                                 $authorizedkeysfile              = '/etc/ssh/local_keys/%u',
   Optional[Stdlib::Absolutepath]                         $authorizedkeyscommand           = undef,
   String                                                 $authorizedkeyscommanduser       = 'nobody',
@@ -460,7 +465,9 @@ class ssh::server::conf (
     ssh::add_sshd_config('AuthorizedKeysCommand', '/usr/libexec/openssh/ssh-ldap-wrapper', $remove_entries)
     ssh::add_sshd_config('AuthorizedKeysCommandUser', $authorizedkeyscommanduser, $remove_entries)
   }
-  ssh::add_sshd_config('AuthorizedKeysFile', $authorizedkeysfile, $remove_entries)
+  if $manage_authorizedkeysfile {
+    ssh::add_sshd_config('AuthorizedKeysFile', $authorizedkeysfile, $remove_entries)
+  }
   ssh::add_sshd_config('Banner', $banner, $remove_entries)
   ssh::add_sshd_config('ChallengeResponseAuthentication', ssh::config_bool_translate(defined('$_challengeresponseauthentication') ? { true => $_challengeresponseauthentication, default => $challengeresponseauthentication } ), $remove_entries)
   ssh::add_sshd_config('Ciphers', $_ciphers, $remove_entries)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -60,6 +60,16 @@ describe 'ssh class' do
         end
       end
 
+      context 'with turning off AuthorizedKeysFile management'
+        disable_manage_authorizedkeysfile = server_hieradata.merge(
+          { 'ssh::server::conf::manage_authorizedkeysfile' => false,
+            'ssh::server::conf::authorizedkeysfile'        => '/foo/bar' }
+        )
+        set_hieradata_on(server, disable_fallback_hieradata)
+        apply_manifest_on(server, disable_manage_authorizedkeysfile, catch_changes: true)
+        File.read('/etc/ssh/sshd_config').should_not match('AuthorizedKeysFile\s*/foo/bar')
+      end
+
       context 'logging into machines as root' do
 
         it 'should set the root password' do


### PR DESCRIPTION
The new parameter 'manage_authorizedkeysfile', will be set to true by
default, which means base functionality of the class will not change at
all. If a user flips the variable to false, the authorizedkeysfile
variable will be ignored, allowing users to preserve their existing ssh
key infrastructure.

Fixes #143