### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.14.0
+- Add RockyLinux 8 support
+
 * Sat Oct 15 2022 Trevor Vaughan <trevor@sicura.us> - 6.13.1
 - Remove unnecessary augeasproviders_core module dependency
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/client/host_config_entry.pp
+++ b/manifests/client/host_config_entry.pp
@@ -578,9 +578,9 @@ define ssh::client::host_config_entry (
   }
   ssh_config{
     default:
-      host   => $name,
+      ensure => $_ensure,
       target => $target,
-      ensure => $_ensure
+      host   => $name,
     ;
     "${_name}__CompressionLevel":
       key   => 'CompressionLevel',
@@ -647,8 +647,8 @@ define ssh::client::host_config_entry (
 
   if $hostkeyalgorithms{
     ssh_config { "${_name}__HostKeyAlgorithms":
-      key   => 'HostKeyAlgorithms',
-      value => $hostkeyalgorithms,
+      key    => 'HostKeyAlgorithms',
+      value  => $hostkeyalgorithms,
       host   => $name,
       target => $target,
     }

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -307,7 +307,7 @@ class ssh::server::conf (
 
 #### SIMP parameters ####
   String                                                 $app_pki_external_source         = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
-  Stdlib::Absolutepath                                   $app_pki_key                     = "/etc/pki/simp_apps/sshd/x509/private/${facts['fqdn']}.pem",
+  Stdlib::Absolutepath                                   $app_pki_key                     = "/etc/pki/simp_apps/sshd/x509/private/${facts['networking']['fqdn']}.pem",
   Boolean                                                $enable_fallback_ciphers         = true,
   Array[String]                                          $fallback_ciphers                = $ssh::server::params::fallback_ciphers,
   Boolean                                                $fips                            = simplib::lookup('simp_options::fips', { 'default_value' => false }),
@@ -541,7 +541,7 @@ class ssh::server::conf (
   }
 
   $_ports.each |Simplib::Port $sel_port| {
-    if ($sel_port != 22) and $facts['selinux_enforced'] {
+    if ($sel_port != 22) and $facts['os']['selinux']['enforced'] {
       if simplib::module_exist('simp/selinux') {
         simplib::assert_optional_dependency($module_name, 'simp/selinux')
         simplib::assert_optional_dependency($module_name, 'simp/vox_selinux')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.13.1",
+  "version": "6.14.0",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -86,6 +86,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -504,6 +504,13 @@ describe 'ssh::server::conf' do
           :openssh_version  => latest_openssh_version,
           :selinux_enforced => true
         } )
+        os_facts[:selinux] = true
+        os_facts[:os][:selinux][:config_mode] = 'enforcing'
+        os_facts[:os][:selinux][:config_policy] = 'targeted'
+        os_facts[:os][:selinux][:current_mode] = 'enforcing'
+        os_facts[:os][:selinux][:enabled] = true
+        os_facts[:os][:selinux][:enforced] = true
+        os_facts
       }
 
       context 'with a non-standard ssh port' do


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync, and may also apply other updates to ensure conformity.