### PR TITLE
Remove use of File.exists?

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Oct 18 2023 Steven Pritchard <steve@sicura.us> - 6.16.1
+- Replace calls to `File.exists?` with `File.exist?` for compatibility with
+  Ruby 3
+
 * Wed Oct 11 2023 Steven Pritchard <steve@sicura.us> - 6.16.0
 - [puppetsync] Updates for Puppet 8
   - These updates may include the following:

--- a/lib/puppet/functions/ssh/autokey.rb
+++ b/lib/puppet/functions/ssh/autokey.rb
@@ -71,7 +71,7 @@ Puppet::Functions.create_function(:'ssh::autokey', Puppet::Functions::InternalFu
       end
     end
 
-    if ( !File.exists?("#{keydir}/#{username}") )
+    if ( !File.exist?("#{keydir}/#{username}") )
       begin
         Timeout::timeout(30) do
           Puppet::Util::Execution.execute("/usr/bin/ssh-keygen -N '' -q -t rsa -C '' -b #{key_strength} -f #{keydir}/#{username}")
@@ -83,7 +83,7 @@ Puppet::Functions.create_function(:'ssh::autokey', Puppet::Functions::InternalFu
       end
     end
 
-    if ( File.exists?("#{keydir}/#{username}.pub") )
+    if ( File.exist?("#{keydir}/#{username}.pub") )
       if return_private
         retval = File.read("#{keydir}/#{username}")
       else

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.16.0",
+  "version": "6.16.1",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replace calls to `File.exists?` with `File.exist?` for compatibility with Ruby 3

Closes #165