### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 6.18.0
+- [puppetsync] Add EL9 support
+
 * Wed Dec 06 2023 Mike Riddle <mike@sicura.us> - 6.17.1
 - The module will now correctly handle a situation where /etc/localtime doesn't exist
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
-* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 6.18.0
-- [puppetsync] Add EL9 support
+* Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 6.18.0
+- [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 
 * Wed Dec 06 2023 Mike Riddle <mike@sicura.us> - 6.17.1
 - The module will now correctly handle a situation where /etc/localtime doesn't exist

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.17.1",
+  "version": "6.18.0",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",
@@ -51,7 +51,7 @@
       },
       {
         "name": "simp/pam",
-        "version_requirement": ">= 6.8.3 < 7.0.0"
+        "version_requirement": ">= 6.8.3 < 8.0.0"
       },
       {
         "name": "simp/selinux",


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.