### PR TITLE
quoted ssh command should work on windows and linux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jun 18 2024 Rick Gardner <Rick@sicura.us> - 6.18.1
+- Fixed custom fact on windows bug
+
 * Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 6.18.0
 - [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 

--- a/lib/facter/openssh_version.rb
+++ b/lib/facter/openssh_version.rb
@@ -14,7 +14,7 @@ Facter.add("openssh_version") do
 
     # There is no explicit version or help flag for sshd.  Pass
     # a garbage '-v' flag, and grab the output.
-    sshd_out = Facter::Core::Execution.execute(%(#{sshd_command} -v 2>&1))
+    sshd_out = Facter::Core::Execution.execute(%(\"#{sshd_command}\" -v 2>&1))
 
     # Case insensitive match to openssh followed by any characters (or no characters),
     # proceeded by digits(any number) and decimals.  Return the digits and decimals.

--- a/lib/facter/ssh_host_keys.rb
+++ b/lib/facter/ssh_host_keys.rb
@@ -13,7 +13,7 @@ Facter.add("ssh_host_keys") do
     hostkeys = []
 
     # sshd -T lists the config dump, which should list all hostkeys
-    sshd_out = Facter::Core::Execution.execute(%(#{sshd_command} -T)).split("\n")
+    sshd_out = Facter::Core::Execution.execute(%(\"#{sshd_command}\" -T)).split("\n")
 
     # Need to strip off the hostkey setting key and space
     hostkeys = sshd_out.grep(/^hostkey /).collect { |x|

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-ssh",
-  "version": "6.18.0",
+  "version": "6.18.1",
   "author": "SIMP Team",
   "summary": "Manage ssh",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes #174

Tested on windows 11 box:
`C:\Users\vagrant\Custom_facts>facter --custom-dir ./ ssh_host_keys
[
  "__PROGRAMDATA__\ssh/ssh_host_rsa_key",
  "__PROGRAMDATA__\ssh/ssh_host_ecdsa_key",
  "__PROGRAMDATA__\ssh/ssh_host_ed25519_key"
]

C:\Users\vagrant\Custom_facts>facter --custom-dir ./ openssh_version
8.0
`

Tested on rocky8:
`[root@rocky8 custom_facts]# facter --custom-dir ./ openssh_version

8.0

[root@rocky8 custom_facts]# facter --custom-dir ./ ssh_host_keys

[
  "/etc/ssh/ssh_host_rsa_key"
]`