### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,6 @@ fixtures:
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     selinux: https://github.com/simp/pupmod-simp-selinux.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     sshkeys_core: https://github.com/simp/pupmod-puppetlabs-sshkeys_core.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -244,7 +244,6 @@ The following parameters are available in the `ssh::server::conf` class:
 * [`strictmodes`](#-ssh--server--conf--strictmodes)
 * [`subsystem`](#-ssh--server--conf--subsystem)
 * [`syslogfacility`](#-ssh--server--conf--syslogfacility)
-* [`tcpwrappers`](#-ssh--server--conf--tcpwrappers)
 * [`usepam`](#-ssh--server--conf--usepam)
 * [`manage_pam_sshd`](#-ssh--server--conf--manage_pam_sshd)
 * [`oath`](#-ssh--server--conf--oath)
@@ -592,14 +591,6 @@ Data type: `Ssh::Syslogfacility`
 Gives the facility code that is used when logging messages.
 
 Default value: `'AUTHPRIV'`
-
-##### <a name="-ssh--server--conf--tcpwrappers"></a>`tcpwrappers`
-
-Data type: `Boolean`
-
-If true, enable sshd tcpwrappers.
-
-Default value: `simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })`
 
 ##### <a name="-ssh--server--conf--usepam"></a>`usepam`
 

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -146,9 +146,6 @@
 # @param syslogfacility
 #   Gives the facility code that is used when logging messages.
 #
-# @param tcpwrappers
-#   If true, enable sshd tcpwrappers.
-#
 # @param usepam
 #   Enables the Pluggable Authentication Module interface.
 #
@@ -298,7 +295,6 @@ class ssh::server::conf (
   Boolean                                                $strictmodes                     = true,
   String                                                 $subsystem                       = 'sftp /usr/libexec/openssh/sftp-server',
   Ssh::Syslogfacility                                    $syslogfacility                  = 'AUTHPRIV',
-  Boolean                                                $tcpwrappers                     = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }),
   Variant[Boolean,Enum['sandbox']]                       $useprivilegeseparation          = 'sandbox',
   Boolean                                                $x11forwarding                   = false,
   Optional[Hash[String[1],NotUndef]]                     $custom_entries                  = undef,
@@ -575,14 +571,4 @@ class ssh::server::conf (
     }
   }
 
-  if $tcpwrappers {
-    simplib::assert_optional_dependency($module_name, 'simp/tcpwrappers')
-
-    include 'tcpwrappers'
-
-    tcpwrappers::allow { 'sshd':
-      pattern => simplib::nets2ddq($trusted_nets),
-      order   => 1
-    }
-  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -46,10 +46,6 @@
         "version_requirement": ">= 6.2.0 < 7.0.0"
       },
       {
-        "name": "simp/tcpwrappers",
-        "version_requirement": ">= 6.2.0 < 7.0.0"
-      },
-      {
         "name": "simp/pam",
         "version_requirement": ">= 6.8.3 < 8.0.0"
       },

--- a/spec/classes/server/conf_spec.rb
+++ b/spec/classes/server/conf_spec.rb
@@ -119,7 +119,6 @@ describe 'ssh::server::conf' do
       it { is_expected.not_to contain_class('oath') }
       it { is_expected.not_to contain_file('/etc/pam.d/sshd') }
       it { is_expected.not_to contain_class('iptables') }
-      it { is_expected.not_to contain_class('tcpwrappers') }
     end
 
     context 'latest openssh_version and only simp_options::fips true' do
@@ -477,15 +476,13 @@ describe 'ssh::server::conf' do
       it { is_expected.to contain_sshd_config('AuthorizedKeysCommandUser').with_value('nobody') }
     end
 
-    context 'with firewall, haveged, pam, and tcpwrappers global catalysts enabled' do
+    context 'with firewall, haveged, and pam global catalysts enabled' do
       let(:hieradata) { 'some_global_catalysts_enabled' }
 
       it { is_expected.to compile.with_all_deps }
       it_behaves_like('it creates sshd_config with notify', 'UsePAM', 'yes')
       it { is_expected.to contain_class('iptables') }
       it { is_expected.to contain_iptables__listen__tcp_stateful('allow_sshd').with_dports([22]) }
-      it { is_expected.to contain_class('tcpwrappers') }
-      it { is_expected.to contain_tcpwrappers__allow('sshd') }
       it { is_expected.to contain_class('haveged') }
     end
 

--- a/spec/fixtures/hieradata/global_catalysts_enabled.yaml
+++ b/spec/fixtures/hieradata/global_catalysts_enabled.yaml
@@ -8,4 +8,3 @@ simp_options::ldap : true
 simp_options::pam : true
 simp_options::pki : true
 simp_options::sssd : true
-simp_options::tcpwrappers : true

--- a/spec/fixtures/hieradata/some_global_catalysts_enabled.yaml
+++ b/spec/fixtures/hieradata/some_global_catalysts_enabled.yaml
@@ -2,4 +2,3 @@
 simp_options::firewall : true
 simp_options::haveged : true
 simp_options::pam : true
-simp_options::tcpwrappers : true


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.