### PR TITLE
Fix tag_deploy for the simp-rake-helpers 6.x stack

### DIFF
--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:
@@ -55,7 +55,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
@@ -180,7 +180,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - name: Build Puppet module (PDK)
         run: bundle exec pdk build --force


### PR DESCRIPTION
Fix tag_deploy for the simp-rake-helpers 6.x stack

The tag/release workflow still ran under Ruby 2.7.8 with
PUPPET_VERSION '~> 7' (mapped to openvox ~> 7 by the Gemfile), which
cannot resolve against simp-rake-helpers >= 6.0 (requires openvox
>= 8 < 9), so the tag & release jobs failed. Align with the pr_tests
openvox8 lane: Ruby 3.2.11 and PUPPET_VERSION '~> 8'.

Unblocks the failed release tag deploy. NOTE: tag-triggered workflows run the workflow file **at the tag's ref**, so after merging, delete and re-create the tag on the new master commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)